### PR TITLE
platform-ci.yaml: Add run flags from pipelines

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -245,7 +245,7 @@ jobs:
       working-directory: "Z:"
       env:
         RUST_ENV_CHECK_TOOL_EXCLUSIONS: "cargo fmt, cargo tarpaulin"
-      run: stuart_build -c ${{ matrix.build_file }} TARGET=DEBUG TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} --FlashRom
+      run: stuart_build -c ${{ matrix.build_file }} TARGET=DEBUG TOOL_CHAIN_TAG=${{ matrix.tool_chain_tag }} SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE EMPTY_DRIVE=TRUE BLD_*_QEMU_CORE_NUM=2 --FlashRom
 
     - name: Build Cleanup
       id: build_cleanup


### PR DESCRIPTION
## Description

Adds the same flags used in the pipelines for running the image on QEMU to EFI shell in CI.

Required PR status checks were not set yet and the previous PR auto merged. This is primarily needed to shutdown QEMU after reaching shell.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Local build and CI (testing in GitHub workflow in the PR)

## Integration Instructions

N/A