### PR TITLE
Fix Typo in Build and Run Script

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -349,7 +349,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
             "make",
             "sbsa",
         ]
-        build_cmd.extend([str(p) for p in args.patch])
+        build_cmd.extend([str(p) for p in args.crate_patch])
         if args.qemu_path:
             qemu_exec = args.qemu_path, "qemu-system-aarch64"
         else:


### PR DESCRIPTION
## Description

During PR review of the command to add crate patching support to the build script, a rename of the arg was requested, but it was missed to be renamed in one place, causing the script to crash when running SBSA. This replaces the wrong name.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running the script on SBSA.

## Integration Instructions

N/A.
