### PR TITLE
Patina Setup Guide - Validated on QEMU - Windows/Linux/WSL - X64/AArch64

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -98,14 +98,12 @@ which is not ideal due to language and tooling differences.
 There are two platforms currently supported in this repository - `QemuQ35Pkg` and `QemuSbsaPkg`.
 
 - [QemuQ35Pkg](https://github.com/OpenDevicePartnership/patina-qemu/tree/main/Platforms/QemuQ35Pkg)
-  - Intel Q35 chipset with ICH9 south bridge
+  - Intel Q35 chipset with ICH9 south bridge and AMD Cpu
   - This demonstrates x86/x64 UEFI firmware development with Patina.
   - [QemuQ35Pkg Detailed Info](https://github.com/OpenDevicePartnership/patina-qemu/blob/main/Platforms/Docs/Q35/QemuQ35_ReadMe.md)
 - [QemuSbsaPkg](https://github.com/OpenDevicePartnership/patina-qemu/tree/main/Platforms/QemuSbsaPkg)
   - ARM Server Base System Architecture
   - This demonstrates AARCH64 UEFI firmware development with Patina.
-  - Note: `QemuSbsaPkg` could build in the past on Windows using the `CLANGPDB` toolchain. However, this is no longer
-    possible due to some code that is part of the build that only builds only Linux at this time.
   - [QemuSbsaPkg Detailed Info](https://github.com/OpenDevicePartnership/patina-qemu/blob/main/Platforms/Docs/SBSA/QemuSbsa_ReadMe.md)
 
   **Supported Host Platforms and Target Architectures**


### PR DESCRIPTION
## Description

This PR improves the **Patina-QEMU** front page documentation (`README.md`) to make it more self-contained and comprehensive. It updates the first-time setup instructions, listing both the automated `workspace_setup.py` script and detailed manual setup steps. The goal is to help users easily build and run `patina` with QEMU on **Windows 11 (24H2)**, **Linux (Ubuntu 24.04 LTS)**, and **WSL**, for both **x64** and **AArch64** architectures — all without needing to leave the `README.md`.

All configurations have been thoroughly tested and are current as of 05/28. 😄

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

Please use the rendered page on the [branch](https://github.com/OpenDevicePartnership/patina-qemu/blob/users/vineelko/patina_setup_guide_0529/Readme.md#first-time-setup-instructions-for-this-repository) for code review.

## How This Was Tested
Windows/X64: ![image](https://github.com/user-attachments/assets/c5ea606a-60d5-47ae-a9c7-f14b245e6290)
Windows/AArch64: ![image](https://github.com/user-attachments/assets/6dacbf1a-5684-4223-b668-227252f90225)
Linux/X64: ![image](https://github.com/user-attachments/assets/6864d8cc-7e22-4b92-9f3d-e816cf743d0d)
Linux/AArch64: ![image](https://github.com/user-attachments/assets/5aee740e-4c01-41e9-8822-a5291a90d0b0)


## Integration Instructions

NA
