### PR TITLE
Minor doc fix: use cargo make q35

### DIFF
--- a/Platforms/Docs/Common/windbg-qemu-uefi-debugging.md
+++ b/Platforms/Docs/Common/windbg-qemu-uefi-debugging.md
@@ -82,7 +82,7 @@ In `C:\r\patina-dxe-core-qemu\bin\q35_dxe_core.rs`, modify the `DEBUGGER` initia
 Then build using:
 
 ```sh
-cargo build_q35
+cargo make q35
 ```
 
 This produces the dxe core binary at:


### PR DESCRIPTION
## Description

use cargo make q35 instead of use cargo build_q35

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA