### PR TITLE
build_and_run_rust_binary.py: Exit on Rust build failure

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -477,12 +477,16 @@ def _build_rust_dxe_core(settings: Dict[str, Path]) -> None:
     if "-Zunstable-options" in settings["build_cmd"]:
         env["RUSTC_BOOTSTRAP"] = "1"
 
-    if settings["build_target"] == "RELEASE":
-        subprocess.run(
-            settings["build_cmd"] + ["--profile", "release"], check=True, env=env
-        )
-    else:
-        subprocess.run(settings["build_cmd"], check=True, env=env)
+    try:
+        if settings["build_target"] == "RELEASE":
+            subprocess.run(
+                settings["build_cmd"] + ["--profile", "release"], check=True, env=env
+            )
+        else:
+            subprocess.run(settings["build_cmd"], check=True, env=env)
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Build failed with error #{e.returncode}.")
+        sys.exit(e.returncode)
 
 
 def _patch_rust_binary(settings: Dict[str, Path]) -> None:


### PR DESCRIPTION
## Description

Closes #24 

Exit the binary patching process if the Rust build fails.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verify exit code from cargo command is propagated to `subprocess.run`
- Verify the script exits on an error return code

## Integration Instructions

N/A