### PR TITLE
Patina DXE Core Release Binary Composition and Size Optimizations - Part 2

### DIFF
--- a/Platforms/Docs/Common/patina_dxe_core_release_binary_size.md
+++ b/Platforms/Docs/Common/patina_dxe_core_release_binary_size.md
@@ -1,33 +1,40 @@
 
-# Patina DXE Core Release Binary Composition and Size Optimization
+# Patina DXE Core Release Binary Composition and Size Optimizations
 
 This document serves as a reference for the current set of size-related
-optimizations performed on the DXE Core release binary (even if the numbers
-listed below may eventually become outdated). It also summarizes the current
-binary composition after the optimizations.
+optimizations performed on the Patina DXE Core release binary.
 
-TL;DR: Below is a summary of the current status of the QEMU DXE Core binary
-size, marking the logical conclusion of the size optimization efforts—from
-1,162 KB down to 762 KB (a reduction of approximately 35%). An additional 150 KB
-reduction is possible (but not applied) by completely disabling logging bringing
-the binary size to 599 KB, as documented below.
+**TL;DR:** Below is a summary of the current status of the QEMU DXE Core binary
+size, marking the logical conclusion of the size optimization efforts.
+
+1. Rust compiler size related optimizations (**Applied**)
+2. Disabling logging can save an additional 150KB (**Not Applied**)
+3. Defaulting to UEFI decompression in the section extractor while skipping
+   Brotli and CRC32 can save another 150KB (**Not Applied**)
+4. Excluding patina debugger support will save another 55KB (**Not Applied**)
+
+Bringing the size from 1,162 KB to **406 KB** (A reduction of 65%). The details
+are documented below.
+
+## 1. Common Rust compiler optimizations focused on reducing binary size
+
+**Optimization Status:** Applied
 
 ```toml
 [profile.release]
 codegen-units = 1               # Default is 16; setting it to 1 prioritizes size over compilation speed.
 debug = "full"
-lto = true                      # Enables Link Time Optimization — significant size reduction.
-opt-level = "s"                 # Optimize for size — significant size reduction.
+lto = true                      # Enables Link Time Optimization - significant size reduction.
+opt-level = "s"                 # Optimize for size - significant size reduction.
 split-debuginfo = "packed"
-strip = "symbols"              # Remove symbol information from the final binary(not very relevant for PE files).
+strip = "symbols"               # Remove symbol information from the final binary(not very relevant for PE files).
 incremental = true
 ```
 
 Below is the composition of the Patina DXE Core release binary for QEMU, located
 at `target\x86_64-unknown-uefi\release\qemu_q35_dxe_core.efi`. This represents
 the final binary after applying the non-destructive compiler optimizations
-outlined in [PR
-#19](https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/pull/19):
+outlined in [PR #19](https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/pull/19):
 
 | Segment       | Size on Disk |
 | ------------- | -----------: |
@@ -38,71 +45,102 @@ outlined in [PR
 | miscellaneous |       4.0 KB |
 | **Total**     |   **762 KB** |
 
-## .text Segment Details
+**Results:** **1,162 KB** down to **762 KB** (a reduction of approximately **35%**)
 
-The `.text` segment comprises over 1,050 functions and accounts for 495 KB of
-the binary. Remarkably, fewer than 40 of these functions make up approximately
-**43% (212 KB)** of the `.text` segment.
+## 2. Logging: Reducing Binary Size by Disabling Logging
 
-| Size on Disk | Name                                                                                                                                               |
-| -----------: | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-|     33.79 KB | `qemu_q35_dxe_core::_start(enum core::ffi::c_void*)`                                                                                               |
-|     19.88 KB | `patina_debugger::debugger::impl$4::handle_interrupt<enum2$<patina_sdk::serial::uart::Uart16550> >(....)`                                          |
-|     18.72 KB | `goblin::pe::PE::parse_with_opts(ref$<slice2$<u8> >, goblin::pe::options::ParseOptions*)`                                                          |
-|     13.72 KB | `patina_section_extractor::composite::impl$1::extract(patina_section_extractor::composite::CompositeSectionExtractor*, mu_pi::fw_fs::Section*)`    |
-|     10.08 KB | `patina_dxe_core::image::core_load_image()`                                                                                                        |
-|      9.93 KB | `brotli_decompressor::decode::ProcessCommandsInternal<>(bool, ...)`                                                                                |
-|      7.90 KB | `patina_dxe_core::driver_services::core_connect_controller(...)`                                                                                   |
-|      5.89 KB | `patina_dxe_core::protocol_db::SpinLockedProtocolDb::install_protocol_interface(....)`                                                             |
-|      5.61 KB | `brotli_decompressor::decode::ReadHuffmanCode<>(...)`                                                                                              |
-|      5.50 KB | `AsmIdtVectorBegin`                                                                                                                                |
-|      5.45 KB | `patina_dxe_core::dispatcher::core_fw_vol_event_protocol_notify(enum core::ffi::c_void*, enum core::ffi::c_void*)`                                 |
-|      5.24 KB | `patina_dxe_core::dispatcher::core_dispatcher()`                                                                                                   |
-|      5.11 KB | `patina_sdk::component::struct_component::impl$1::initialize<> (*)(.....,qemu_resources::q35::comp..`                                              |
-|      4.45 KB | `patina_internal_cpu::interrupts::x64::interrupt_manager::page_fault_handler(int64, r_efi::protocols::debug_support::SystemContext)`               |
-|      4.00 KB | `goblin::pe::debug::DebugData::parse_with_opts_and_fixup(....)`                                                                                    |
-|      3.93 KB | `patina_dxe_core::pecoff::UefiPeInfo::parse(ref$<slice2$<u8> >)`                                                                                   |
-|      3.78 KB | `patina_mtrr::mtrr::MtrrLib<>::mtrr_lib_set_memory_ranges<X64Hal>(....)`                                                                           |
-|      3.74 KB | `core::slice::sort::unstable::quicksort::quicksort`                                                                                                |
-|      3.55 KB | `patina_internal_cpu::interrupts::x64::interrupt_manager::general_protection_fault_handler(int64, r_efi::protocols::debug_support::SystemContext)` |
-|      3.42 KB | `goblin::pe::tls::TlsData::parse_with_opts(...)`                                                                                                   |
-|      3.35 KB | `patina_dxe_core::gcd::spin_locked_gcd::SpinLockedGcd::set_memory_space_attributes(unsigned int64, unsigned int64, unsigned int64)`                |
-|      2.89 KB | `patina_dxe_core::image::core_unload_image(enum core::ffi::c_void*, bool)`                                                                         |
-|      2.75 KB | `patina_dxe_core::protocol_db::SpinLockedProtocolDb::register_protocol_notify(r_efi::base::Guid, enum core::ffi::c_void*)`                         |
-|      2.58 KB | `patina_dxe_core::memory_attributes_table::core_install_memory_attributes_table()`                                                                 |
-|      2.55 KB | `patina_dxe_core::driver_services::core_disconnect_controller(....)`                                                                               |
-|      2.45 KB | `patina_dxe_core::allocator::AllocatorMap::get_or_create_allocator(unsigned int, enum core::ffi::c_void*)`                                         |
-|      2.42 KB | `enum2$<alloc::collections::btree::map::entry::Entry<...>(...)`                                                                                    |
-|      2.32 KB | `goblin::pe::import::ImportData::parse_with_opts<u32>(...)`                                                                                        |
-|      2.29 KB | `core::slice::sort::stable::quicksort::quicksort<>()`                                                                                              |
-|      2.28 KB | `goblin::pe::import::ImportData::parse_with_opts<u64>(...)`                                                                                        |
-|      2.27 KB | `patina_mtrr::mtrr::MtrrLib<patina_mtrr::hal::X64Hal>::mtrr_lib_calculate_subtractive_path<patina_mtrr::hal::X64Hal>(...)`                         |
-|      2.17 KB | `patina_internal_cpu::paging::x64::apply_caching_attributes<patina_mtrr::mtrr::MtrrLib<patina_mtrr::hal::X64Hal> >(...)`                           |
-|      2.12 KB | `patina_dxe_core::event_db::SpinLockedEventDb::create_event(....)`                                                                                 |
-|      2.08 KB | `alloc::collections::btree::map::BTreeMap<>(....)`                                                                                                 |
-|      2.06 KB | `alloc::collections::btree::map::BTreeMap<>(....)`                                                                                                 |
-|      2.03 KB | `patina_dxe_core::runtime::set_virtual_address_map(...)`                                                                                           |
+**Optimization Status:** Not Applied
 
-## .rdata Segment Details
-
-The `.rdata` segment consists of 115 data members totaling 249.5 KB. Remarkably,
-just 3 of these data items account for approximately **56% (137 KB)** of the
-segment.
-
- | Size on disk | Name                                                 |
- | -----------: | ---------------------------------------------------- |
- |     119.9 KB | `brotli_decompressor::dictionary::kBrotliDictionary` |
- |      16.0 KB | `crc32fast::table::CRC32_TABLE`                      |
- |       2.0 KB | `brotli_decompressor::context::kContextLookup`       |
-
-## Reducing Binary Size by Disabling Logging
-
-The only further substantial reduction in the release binary size is observed
-when logging is completely disabled, as shown below in
-`\patina-dxe-core-qemu\Cargo.toml` using `release_max_level_off`. This reduces
-the size from 762 KB to 599 KB — a reduction of approximately **21% (150 KB)**.
+The other substantial reduction in the release binary size is observed when
+logging is completely disabled, as shown below in
+`\patina-dxe-core-qemu\Cargo.toml` using `release_max_level_off`.
 
 ```toml
 [dependencies]
 log = { version = "^0.4", default-features = false, features = ["release_max_level_off"] }
 ```
+
+**Results:** **762 KB** to **599 KB** (a reduction of approximately **160 KB**(**21%**))
+
+## 3. Decompression: Reducing Binary Size by Defaulting to UEFI decompression
+
+**Optimization Status:** Not Applied
+
+Next, Defaulting to UEFI decompression in the section extractor while skipping
+Brotli and CRC32 can save another 140KB.
+
+```toml
+[dependencies]
+patina_section_extractor = {  version = "4", registry = "patina-fw", default-features = false, features=["uefi_decompress"] }
+```
+
+**Results:** **599 KB** to **460 KB** (a reduction of approximately **140 KB**(**23%**))
+
+## 4. Debugger: Reducing Binary Size by excluding debugger support
+
+**Optimization Status:** Not Applied
+
+Next, Excluding debugger support can save another 55KB. This reduces the size
+from 460 KB to **~406 KB**.
+
+```rust
+// Commenting below lines will exclude debugger support
+static DEBUGGER: patina_debugger::PatinaDebugger<Uart16550> =
+    patina_debugger::PatinaDebugger::new(Uart16550::Io { base: 0x3F8 })
+        .with_force_enable(false)
+        .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
+
+    patina_debugger::set_debugger(&DEBUGGER);
+```
+
+```toml
+[dependencies]
+# Commenting below line will exclude debugger support
+# patina_debugger = { version = "4", registry = "patina-fw" }
+```
+
+**Results:** **460 KB** to **406 KB** (a reduction of approximately **55 KB**(**11%**))
+
+## Release binary size after above optimizations
+
+```cmd
+C:\r\patina-dxe-core-qemu>dir C:\r\patina-dxe-core-qemu\target\x86_64-unknown-uefi\release\qemu_q35_dxe_core.efi
+ Volume in drive C has no label.
+ Volume Serial Number is 40DF-F702
+
+ Directory of C:\r\patina-dxe-core-qemu\target\x86_64-unknown-uefi\release
+
+06/24/2025  04:53 PM           406,528 qemu_q35_dxe_core.efi
+               1 File(s)        406,528 bytes
+               0 Dir(s)  183,428,534,272 bytes free
+```
+
+## Project MU vs Patina FV size comparison
+
+Up to this point, we have seen what constitutes the Rust DXE Core binary and how
+it can be optimized. This section attempts to perform a platform image-level
+comparison between a C-based UEFI firmware image and a Rust-based Patina UEFI
+firmware image. There are many components that differ between the C-based UEFI
+and the Rust-based UEFI images. Below is a summary of the components that have
+been folded into the Rust DXE Core. On the left, you can see the size
+represented by the Project MU-based QEMU FV file (DxeCore, RuntimeDxe, CpuDxe),
+and on the right, the size represented by the Patina FV file (DxeCore).
+
+| Module     |                     Mu |                 Patina |
+| ---------- | ---------------------: | ---------------------: |
+| DxeCore    |     0x2EC3E (188.0 KB) |     0x63430 (405.0 KB) |
+| RuntimeDxe |        0x206E (8.1 KB) |                        |
+| CpuDxe     |     0x19266 (100.2 KB) |                        |
+| **TOTAL**  | **0x49F12 (296.3 KB)** | **0x63430 (405.0 KB)** |
+
+All in all, the Rust binary includes the following additional features that are
+not available in the C-based UEFI image, with a size increase of approximately
+110 KB compared to the C-based image:
+
+- It incorporates functionality that is typically split across multiple EFI
+  binaries (DxeCore, RuntimeDxe, CpuDxe) in C-based implementations.
+- It includes advanced features such as built-in source-level debugging
+  capabilities.
+- It supports two dispatchers: pure Rust component dispatch and FFS dispatch.
+- It provides stringent memory protection features not present in most C-based
+  DXE Core implementations.


### PR DESCRIPTION
## Description

The PR provides a detailed size comparison between the Project MU based QEMU FV file (DxeCore, RuntimeDxe, CpuDxe) and the Patina FV file (DxeCore) and also updates the doc on size related optimization performed on patina release binary.

https://github.com/OpenDevicePartnership/patina/issues/525

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA
