### PR TITLE
workspace_setup.py: Support python 3.11

### DIFF
--- a/workspace_setup.py
+++ b/workspace_setup.py
@@ -875,7 +875,7 @@ class _Wizard:
         cmd = [
             "stuart_setup",
             "-c",
-            f"{str(self._settings.package_path / "PlatformBuild.py")}",
+            f"{str(self._settings.package_path / 'PlatformBuild.py')}",
         ]
         _Utils.run_cmd(
             cmd,
@@ -1027,7 +1027,7 @@ class _Wizard:
         cmd = [
             "stuart_update",
             "-c",
-            f"{str(self._settings.package_path / "PlatformBuild.py")}",
+            f"{str(self._settings.package_path / 'PlatformBuild.py')}",
         ]
         if _Utils.get_yes_no_response(stuart_update_prompt):
             _LOGGER.info("\nRunning Stuart Update...\n")


### PR DESCRIPTION
## Description

Removes nested quote usage so that 3.11 continues to be supported

closes #36 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local 3.11 usage no longer crashes

## Integration Instructions

N/A