### PR TITLE
workspace_setup.py: Selected Python version display bugfix

### DIFF
--- a/workspace_setup.py
+++ b/workspace_setup.py
@@ -642,7 +642,7 @@ class _Utils:
         else:
             if not _Utils.get_yes_no_response(
                 "Would you like to create a Python virtual environment using"
-                "\n {selected_install}? (y/n): "
+                f"\n {selected_install}? (y/n): "
             ):
                 _LOGGER.info("Skipping virtual environment creation.")
                 return _PythonInstallation(selected_install, False)


### PR DESCRIPTION
## Description

in workspace_setup.py, When validating creating a virtual environment, the string is a normal string instead of an f-string. This updates the string to be an f-string.

Closes #35 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Local Testing

## Integration Instructions

N/A
