### PR TITLE
Update Rust toolchain to 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 
 [tools]
 cargo-make = "0.37.24"


### PR DESCRIPTION
## Description

Allows the repo to build crates dependent on the 2024 edition.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI and run patch script locally

## Integration Instructions

N/A