### PR TITLE
Update to Patina DXE Core v1.0.0

### DIFF
--- a/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
@@ -3,7 +3,7 @@
     "type": "nuget",
     "name": "DXECORE.QEMU",
     "source": "https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/qemu-dxe-core/nuget/v3/index.json",
-    "version": "0.3.3",
+    "version": "1.0.0",
     "flags": ["set_build_var"],
     "var_name": "BLD_*_DXE_CORE_BINARY_PATH"
 }


### PR DESCRIPTION
## Description

Updates to the latest Patina DXE Core.

Complete set of `patina` changes from the previous release:

https://github.com/OpenDevicePartnership/patina/compare/patina-v4.0.1...patina-v5.0.0

Complete set of `patina-dxe-core-qemu` changes from the previous release:

https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/compare/v0.3.3...v1.0.0

> Note: The changes already merged in https://github.com/OpenDevicePartnership/patina-qemu/pull/45 support the Patina Performance component configuration needed in this update.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI
- Boot Q35 to EFI shell
- Boot Q35 to EFI shell with `BLD_*_PERF_TRACE_ENABLE=TRUE`
- Boot SBSA to EFI shell

## Integration Instructions

N/A