### PR TITLE
Update QemuRunner's formatted string to be python 3.10 compatible

### DIFF
--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -53,7 +53,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             return
 
         tpm_cmd = "swtpm"
-        tpm_args = f"socket --tpmstate dir={"/".join(tpm_path.rsplit("/", 1)[:-1])} --ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
+        tpm_args = f"socket --tpmstate dir={'/'.join(tpm_path.rsplit('/', 1)[:-1])} --ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
 
         # Start the TPM emulator in a separate thread
         ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
@@ -149,7 +149,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         args += f" -smbios type=0,vendor=\"Patina\",version=\"patina-sbsa-{repo_version}\",date={creation_date},uefi=on"
         args += f" -smbios type=1,manufacturer=OpenDevicePartnership,product=\"QEMU SBSA\",family=QEMU,version=\"{'.'.join(qemu_version)}\",serial=42-42-42-42"
-        args += f" -smbios type=3,manufacturer=OpenDevicePartnership,serial=42-42-42-42,asset=SBSA,sku=SBSA"
+        args += " -smbios type=3,manufacturer=OpenDevicePartnership,serial=42-42-42-42,asset=SBSA,sku=SBSA"
 
         if (env.GetValue("QEMU_HEADLESS").upper() == "TRUE"):
             args += " -display none"  # no graphics


### PR DESCRIPTION
## Description
Update SBSA's QemuRunner.py python code to work with python 3.10.
Formatted string was mixing "" in the middle of the string, causing older versions of python to not be able to determine where
a string started/ended.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local compilation. 

## Integration Instructions
No integration necessary. 