### PR TITLE
rust-toolchain.toml: Update to 1.89.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,8 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.89.0"
 
 [tools]
 cargo-make = "0.37.24"
 cargo-tarpaulin = "0.31.5"
 cargo-release = "0.25.12"
+


### PR DESCRIPTION
## Description

Allows patina builds in patching to use 1.89 which is necessary for some features now used.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI build and patch Patina DXE Core with boot to EFI shell

## Integration Instructions

- N/A