### PR TITLE
Integrate QEMU Patina DXE Core v2.0.0 (Patina v11.0.0)

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -319,8 +319,7 @@ INF  QemuQ35Pkg/RustFfiImageTestDxe/RustFfiImageTestDxe.inf
 INF  MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.inf
 INF  MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/StatusCodeHandlerRuntimeDxe.inf
 
-# Equivalent functionality is in DxeRust
-# INF  MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
+INF  MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
 INF  MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
 
 INF  QemuQ35Pkg/8259InterruptControllerDxe/8259.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1033,7 +1033,7 @@
   # Architectural Protocols
   #
   # ArmPkg/Drivers/CpuDxe/CpuDxe.inf
-  # MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
+  MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
   MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf {
     <LibraryClasses>

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -215,7 +215,7 @@ READ_LOCK_STATUS   = TRUE
   # PI DXE Drivers producing Architectural Protocols (EFI Services)
   #
   # INF ArmPkg/Drivers/CpuDxe/CpuDxe.inf
-  # INF MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
+  INF MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
   INF MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
   INF MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleRuntimeDxe.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf

--- a/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
@@ -3,7 +3,7 @@
     "type": "nuget",
     "name": "DXECORE.QEMU",
     "source": "https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/qemu-dxe-core/nuget/v3/index.json",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "flags": ["set_build_var"],
     "var_name": "BLD_*_DXE_CORE_NUGET_FEED_PATH"
 }


### PR DESCRIPTION
## Description

Updates the Patina DXE Core ext dep the latest release.

This release requires `RuntimeDxe` to be included in the flash file, so that is done.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Boot to EFI shell

## Integration Instructions

- N/A - Integrated in this change