### PR TITLE
Build and Run Script: Update Default Qemu Path Per Arch

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -260,7 +260,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
 
         if args.qemu_path:
             qemu_exec = args.qemu_path
-        else:
+        elif os.name == "nt":
             qemu_exec = str(
                 SCRIPT_DIR
                 / "QemuPkg"
@@ -268,6 +268,9 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
                 / "qemu-win_extdep"
                 / "qemu-system-x86_64"
             )
+        else:
+            qemu_exec = "/usr/local/bin/qemu-system-x86_64"
+
         qemu_cmd = [
             qemu_exec,
             "-debugcon",


### PR DESCRIPTION
## Description

Currently, when running the build and run script for Q35, the Windows path is always the default QEMU path. This changes the script to use the Windows path if on Windows and the common Linux path (what the container uses) for Linux by default. It can still be explicitly overridden via CLI.

SBSA is not changed and the Linux path is left as the default because at this point it must be built in Linux.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting Q35 in the container in WSL.

## Integration Instructions

N/A.
