### PR TITLE
patina_smbios: remove SmbiosDxe driver from QemuQ35Pkg FDF and DSC

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -379,9 +379,6 @@ INF  MdeModulePkg/Universal/MemoryTest/NullMemoryTestDxe/NullMemoryTestDxe.inf
 INF  QemuQ35Pkg/SioBusDxe/SioBusDxe.inf
 INF  MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
 
-INF  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf
-INF  QemuQ35Pkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
-
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
 INF  QemuQ35Pkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
+++ b/Platforms/QemuQ35Pkg/QemuQ35PkgCommon.dsc.inc
@@ -1111,15 +1111,6 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
   MdeModulePkg/Bus/Isa/Ps2KeyboardDxe/Ps2KeyboardDxe.inf
 
   #
-  # SMBIOS Support
-  #
-  MdeModulePkg/Universal/SmbiosDxe/SmbiosDxe.inf {
-    <LibraryClasses>
-      NULL|QemuQ35Pkg/Library/SmbiosVersionLib/DetectSmbiosVersionLib.inf
-  }
-  QemuQ35Pkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
-
-  #
   # ACPI Support
   #
   MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf


### PR DESCRIPTION
## Description

remove the SmbiosDxe and SmbiosPlatformDxe driver to support Q35 Patina SMBIOS component integration

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`python build_and_run_rust_binary.py` with Patina SMBIOS component integrated into patina-dxe-core-qemu in q35_dxe_core.rs

## Integration Instructions

Integrate the Patina SMBIOS component in patina-dxe-core-qemu with a platform component and add that platform component to the core:

```
.with_component(SmbiosProvider::new(3, 9))
.with_component(q35_services::smbios_platform::Q35SmbiosPlatform::new())
```
