### PR TITLE
Minor Fix: Change QemuQ35Pkg to QemuQ35PkgX64 in build_and_run_rust_binary.py

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -215,7 +215,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
             code_fd = (
                 SCRIPT_DIR
                 / "Build"
-                / "QemuQ35Pkg"
+                / "QemuQ35PkgX64"
                 / f"{args.build_target.upper()}_{args.toolchain.upper()}"
                 / "FV"
                 / "QEMUQ35_CODE.fd"


### PR DESCRIPTION
## Description

The QEMU Q35 platform build now supports X64 PEI in addition to pre-existing support for IA32 PEI. This platform is built in `QemuQ35PkgX64` instead of `QemuQ35Pkg`. This change updates the default FD path to the 64-bit package build.
- `E:\\repos\\patina-qemu\\Build\\QemuQ35Pkg\\DEBUG_VS2022\\FV\\QEMUQ35_CODE.fd` to
- `E:\\repos\\patina-qemu\\Build\\QemuQ35PkgX64\\DEBUG_VS2022\\FV\\QEMUQ35_CODE.fd`

Reference: Adding support of x64 PEI for Patina QEMU
https://github.com/OpenDevicePartnership/patina-qemu/pull/75

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with QEMU

## Integration Instructions

NA