### PR TITLE
Increase the SEC/PEI ram size for Q35

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -155,10 +155,10 @@ gUefiQemuQ35PkgTokenSpaceGuid.PcdOvmfSecPageTablesBase|gUefiQemuQ35PkgTokenSpace
 0x006000|0x001000
 gEfiMdePkgTokenSpaceGuid.PcdGuidedExtractHandlerTableAddress|gUefiQemuQ35PkgTokenSpaceGuid.PcdGuidedExtractHandlerTableSize
 
-0x010000|0x010000
+0x020000|0x020000
 gUefiQemuQ35PkgTokenSpaceGuid.PcdSecPeiTemporaryRamBase|gUefiQemuQ35PkgTokenSpaceGuid.PcdSecPeiTemporaryRamSize
 
-0x020000|0x0E0000
+0x040000|0x0C0000
 gUefiQemuQ35PkgTokenSpaceGuid.PcdOvmfPeiMemFvBase|gUefiQemuQ35PkgTokenSpaceGuid.PcdOvmfPeiMemFvSize
 FV = PEIFV
 


### PR DESCRIPTION
## Description

With the transition to 64bit PEI, a few hob creators naturally start to produce larger HOBs. This could cause certain build configuration to fail to create hob before the memory becomes available.

This change doubled the size for temporary RAM to accommodate the memory usage.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

After the change, the allocation failure that occurred when the performance build flag was enabled no longer happens.

## Integration Instructions

N/A
