### PR TITLE
Update to patina_dxe_core_qemu v2.2.0

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -626,7 +626,7 @@ FILE FREEFORM = PCD(gZeroTouchPkgTokenSpaceGuid.PcdZeroTouchCertificateFile) {
 # but it is not part of the [FV.DXEFV] firmware volume in this build to support
 # Patina features such as post-build replacement of the DXE Core driver.
 #
-# By default, DXE_CORE_NUGET_FEED_PATH is defined in the DXECORE.QEMU_ext_dep.json
+# By default, DXE_CORE_PATH is defined in the DXECORE.QEMU_ext_dep.json
 # file and indicates the directory that the Stuart build placed the pre-compiled
 # drivers from the Nuget feed.
 #
@@ -661,9 +661,9 @@ FILE DXE_CORE = 23C9322F-2AF2-476A-BC4C-26BC88266C71 {
   SECTION PE32 = $(DXE_CORE_BINARY_OVERRIDE)                                 # User defined override
 !else
   !if $(TARGET) == RELEASE
-    SECTION PE32 = $(DXE_CORE_NUGET_FEED_PATH)/release/qemu_q35_dxe_core.efi # Nuget feed release build
+    SECTION PE32 = $(DXE_CORE_PATH)/release/qemu_q35_dxe_core.efi # Nuget feed release build
   !else
-    SECTION PE32 = $(DXE_CORE_NUGET_FEED_PATH)/debug/qemu_q35_dxe_core.efi   # Nuget feed debug build
+    SECTION PE32 = $(DXE_CORE_PATH)/debug/qemu_q35_dxe_core.efi   # Nuget feed debug build
   !endif
 !endif
   SECTION UI = "DxeCore"

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -472,7 +472,7 @@ READ_LOCK_STATUS   = TRUE
 # but it is not part of the [FV.FvMain] firmware volume in this build to support
 # Patina features such as post-build replacement of the DXE Core driver.
 #
-# By default, DXE_CORE_NUGET_FEED_PATH is defined in the DXECORE.QEMU_ext_dep.json
+# By default, DXE_CORE_PATH is defined in the DXECORE.QEMU_ext_dep.json
 # file and indicates the directory that the Stuart build placed the pre-compiled
 # drivers from the Nuget feed.
 #
@@ -508,9 +508,9 @@ FILE DXE_CORE = 23C9322F-2AF2-476A-BC4C-26BC88266C71 {
   SECTION PE32 = $(DXE_CORE_BINARY_OVERRIDE)                                  # User defined override
 !else
   !if $(TARGET) == RELEASE
-    SECTION PE32 = $(DXE_CORE_NUGET_FEED_PATH)/release/qemu_sbsa_dxe_core.efi # Nuget feed release build
+    SECTION PE32 = $(DXE_CORE_PATH)/release/qemu_sbsa_dxe_core.efi # Nuget feed release build
   !else
-    SECTION PE32 = $(DXE_CORE_NUGET_FEED_PATH)/debug/qemu_sbsa_dxe_core.efi   # Nuget feed debug build
+    SECTION PE32 = $(DXE_CORE_PATH)/debug/qemu_sbsa_dxe_core.efi   # Nuget feed debug build
   !endif
 !endif
   SECTION UI = "DxeCore"

--- a/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
@@ -2,11 +2,11 @@
     "scope": "qemu",
     "type": "web",
     "name": "DXECORE.QEMU",
-    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v2.1.1/patina_dxe_core_qemu.zip",
-    "version": "2.1.1",
-    "sha256": "2ed4c4100a9db743474d25c83f3178a4fcfb7fe5aea9f4a34358fb040ddb5102",
+    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v2.2.0/patina_dxe_core_qemu.zip",
+    "version": "2.2.0",
+    "sha256": "605a8864c5319b38294af56d4ced9bfcb387a07f14a566a37c43e38677cc4870",
     "internal_path": "/",
     "compression_type": "zip",
     "flags": ["set_build_var"],
-    "var_name": "BLD_*_DXE_CORE_NUGET_FEED_PATH"
+    "var_name": "BLD_*_DXE_CORE_PATH"
 }


### PR DESCRIPTION
## Description

This pulls in a newer version of patina_dxe_core_qemu that runs patina tests by default.

This also updates the name of the dxe core path variable to remove nuget from the name, as this is no longer a nuget dependency.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting Q35 and SBSA to shell.

## Integration Instructions

N/A.
