### PR TITLE
QEMU: Expose monitor interface over Telnet for improved debugging

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -140,6 +140,13 @@ def _parse_arguments() -> argparse.Namespace:
         default=None,
         help="Feature set for patina-dxe-core-qemu build"
     )
+    parser.add_argument(
+        "--monitor-port",
+        "-m",
+        type=int,
+        default=None,
+        help="Port to use for QEMU monitor communication.",
+    )
 
     args = parser.parse_args()
     if args.platform == "SBSA" and args.toolchain == "VS2022":
@@ -310,11 +317,13 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
             "cirrus",
             "-serial",
             f"tcp:127.0.0.1:{args.serial_port},server,nowait",
-            "-monitor",
-            "telnet:127.0.0.1:55555,server,nowait",
         ]
+
         if args.gdb_port:
             qemu_cmd += ["-gdb", f"tcp::{args.gdb_port}"]
+
+        if args.monitor_port:
+            qemu_cmd += ["-monitor", f"telnet:127.0.0.1:{args.monitor_port},server,nowait"]
 
         if args.os:
             qemu_cmd += args.os
@@ -424,8 +433,6 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
             "type=1,manufacturer=OpenDevicePartnership,product='QEMU SBSA',family=QEMU,version='9.0.0',serial=42-42-42-42",
             "-smbios",
             "type=3,manufacturer=OpenDevicePartnership,serial=42-42-42-42,asset=SBSA,sku=SBSA",
-            "-monitor",
-            "telnet:127.0.0.1:55555,server,nowait",
         ]
         if args.serial_port:
             qemu_cmd += ["-serial", f"tcp:127.0.0.1:{args.serial_port},server,nowait"]
@@ -434,6 +441,9 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
 
         if args.gdb_port:
             qemu_cmd += ["-gdb", f"tcp::{args.gdb_port}"]
+
+        if args.monitor_port:
+            qemu_cmd += ["-monitor", f"telnet:127.0.0.1:{args.monitor_port},server,nowait"]
 
         if args.os:
             qemu_cmd += args.os


### PR DESCRIPTION
## Description

This enables easier inspection and interaction with the QEMU monitor by making
it accessible(copy stuff) over a Telnet connection using putty.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted Q35 to UEFI shell and connected via putty and inspected the
memory map(`info mtree`) 

## Integration Instructions

NA