### PR TITLE
Minor fix: Make argument values case insensitive

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -94,6 +94,7 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--build-target",
         "-b",
+        type=str.upper,
         choices=["DEBUG", "RELEASE"],
         default="DEBUG",
         help="Build target, either DEBUG or RELEASE.",
@@ -101,6 +102,7 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--platform",
         "-p",
+        type=str.upper,
         choices=["Q35", "SBSA"],
         default="Q35",
         help="QEMU platform such as Q35 or SBSA.",
@@ -108,7 +110,7 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--toolchain",
         "-t",
-        type=str,
+        type=str.upper,
         default="VS2022",
         help="Toolchain to use for building. "
         "Q35 default: VS2022. SBSA default: GCC5.",


### PR DESCRIPTION
## Description

- Prevent below error when arguments are provided in lowercase.
```
python build_and_run_rust_binary.py -t VS2022 -p q35 -g 50002
build_and_run_rust_binary.py: error: argument --platform/-p: invalid choice: 'q35' (choose from Q35, SBSA)
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated the script

## Integration Instructions

NA