### PR TITLE
QemuQ35Pkg: Enable stack cookies in DSC files

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35PkgIA32X64.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35PkgIA32X64.dsc
@@ -59,11 +59,6 @@
   MSFT:*_*_*_CC_FLAGS = /D DISABLE_NEW_DEPRECATED_INTERFACES $(PERFORMANCE_OPTIONS)
   GCC:*_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES $(PERFORMANCE_OPTIONS)
 
-  #
-  # Disable stack cookies in this repo (not supported in Rust modules).
-  #
-  MSFT:*_*_*_CC_FLAGS = /GS-
-
 [BuildOptions.common.PEIM, BuildOptions.common.PEI_CORE, BuildOptions.common.SEC]
   MSFT:*_*_*_DLINK_FLAGS = /ALIGN:64
   GCC:*_GCC5_*_DLINK_FLAGS = -z common-page-size=64

--- a/Platforms/QemuQ35Pkg/QemuQ35PkgX64.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35PkgX64.dsc
@@ -50,11 +50,6 @@
   MSFT:*_*_*_CC_FLAGS = /D DISABLE_NEW_DEPRECATED_INTERFACES $(PERFORMANCE_OPTIONS)
   GCC:*_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES $(PERFORMANCE_OPTIONS)
 
-  #
-  # Disable stack cookies in this repo (not supported in Rust modules).
-  #
-  MSFT:*_*_*_CC_FLAGS = /GS-
-
   MSFT:*_*_*_DLINK_FLAGS = /ALIGN:64
   GCC:*_GCC5_*_DLINK_FLAGS = -z common-page-size=64
   GCC:*_CLANGPDB_*_DLINK_FLAGS = /ALIGN:64 /FILEALIGN:64


### PR DESCRIPTION
## Description

Stack cookies were previously disabled in QemuQ35Pkg because Rust modules were built in the EDK II build process. That's no longer the case after 2cc0281, so stack cookies are reenabled now.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QEMU Q35 boot to EFI shell
- Check that stack cookies are present in local module build files

## Integration Instructions

- N/A