### PR TITLE
Add readiness tool to CI

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -16,6 +16,9 @@ on:
     branches:
       - main
 
+env:
+  DXE_READINESS_TOOL_PATH: QemuPkg/Binaries/READINESS.QEMU_extdep
+
 jobs:
 
   # A job to produce the environment constants for this repository, so that the build job can

--- a/QemuPkg/Binaries/READINESS.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/READINESS.QEMU_ext_dep.json
@@ -8,7 +8,7 @@
     "internal_path": "/",
     "compression_type": "zip",
     "flags": [
-        "set_shell_var"
+        "set_build_var"
     ],
     "var_name": "DXE_READINESS_TOOL_PATH"
 }


### PR DESCRIPTION
## Description
Add readiness tool to CI. It currently runs for Q35 debug (Windows build) and SBSA debug (Linux build).

- [x] Impacts functionality? (only affects CI, not patina-qemu functionality)
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Passes CI on forked repo.

https://github.com/berlin-with0ut-return/patina-qemu/actions/runs/21613565962

## Integration Instructions
N/A. Both platforms should pass.