### PR TITLE
.github: Treat Patina App ID as Secret

### DIFF
--- a/.github/workflows/build-haf-tfa.yml
+++ b/.github/workflows/build-haf-tfa.yml
@@ -32,7 +32,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.PATINA_AUTOMATION_APPLICATION_ID }}
+          app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
           private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Description

It is stored as a secret instead of a variable.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- N/A

## Integration Instructions

- N/A