### PR TITLE
Update `haf-tfa-bin` to use v0.1.1

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -102,14 +102,14 @@ jobs:
             target: 'DEBUG'
             tool-chain: ${{ needs.vars.outputs.linux-toolchain }}
             platform: 'SBSA'
-            extra-args: 'HAF_TFA_BUILD=TRUE'
+            extra-args: ''
             os: 'ubuntu-latest'
             container: ${{ needs.vars.outputs.container-image }}
           - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
             target: 'RELEASE'
             tool-chain: ${{ needs.vars.outputs.linux-toolchain }}
             platform: 'SBSA'
-            extra-args: 'HAF_TFA_BUILD=TRUE'
+            extra-args: ''
             os: 'ubuntu-latest'
             container: ${{ needs.vars.outputs.container-image }}
 

--- a/Platforms/QemuSbsaPkg/Binaries/haf_tfa_binaries_ext_dep.yaml
+++ b/Platforms/QemuSbsaPkg/Binaries/haf_tfa_binaries_ext_dep.yaml
@@ -8,10 +8,10 @@ scope: qemusbsa
 id: haf-tfa-bin
 type: web
 name: HAF_TFA_BUILD
-source: https://github.com/OpenDevicePartnership/patina-qemu/releases/download/v0.1.0/haf-tfa-firmware-v0.1.0.zip
+source: https://github.com/OpenDevicePartnership/patina-qemu/releases/download/v0.1.1/haf-tfa-firmware-v0.1.1.zip
 
-version: v0.1.0
-sha256: 029318b4f2c6f33cf4afdd52e8739feb2d106663baaefb3ac5e85391fcbefce9
+version: v0.1.1
+sha256: f0b669ccd900a358fe0ad6ec86ab97f482c6da50b1192baf2c5b694bac40bcc4
 internal_path: /
 compression_type: zip
 flags:


### PR DESCRIPTION
## Description

This change updates the TF-A and Hafnium binaries to use v0.1.1.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

The pipeline build and run passes.

## Integration Instructions

N/A
