### PR TITLE
CI: Split build and run into two actions

### DIFF
--- a/.github/actions/build-platform/action.yml
+++ b/.github/actions/build-platform/action.yml
@@ -171,7 +171,7 @@ runs:
       $([[ -n "${{ inputs.architecture }}" ]] && echo " -a ${{ inputs.architecture }}")
 
   - name: Move run log
-    if: ${{ always() && inputs.flash }}
+    if: always()
     shell: bash
     env:
       TEMP_DIR: ${{ steps.tempdir.outputs.path }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -164,7 +164,6 @@ jobs:
           tool-chain: ${{ matrix.tool-chain }}
           # Only pass architecture if it is defined in the matrix
           architecture: ${{ matrix.architecture || '' }}
-          flash-only: 'true'
           stuart-args: 'SHUTDOWN_AFTER_RUN=TRUE QEMU_HEADLESS=TRUE BLD_*_QEMU_CORE_NUM=${{ needs.vars.outputs.qemu-core-count }} ${{ matrix.extra-args }}'
       
       - name: Publish Logs


### PR DESCRIPTION
## Description

Github actions have log limits of about 65K. This results in the loss
of visual logs in the workflow (The logs in the log file still exist).
To help combat this, we separate the setup & build from the run command
so that each action has it's own 65KB of logging available. This results
in all logging being visible without needing to download the uploaded
log files

Additionally, this commit updates the action to no longer publish the logs,
but instead returns an output value (`log-path`) that callers of the action can
use. In our case, we publish the logs.

Finally, this commit updates the action to no longer take a `flash` argument,
but instead takes a `command` argument, which can be `build`, `flash`, or `all`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A
