### PR TITLE
QemuRunner: Conditionally pass virtual drive

### DIFF
--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -150,7 +150,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             .with_usb_mouse()
             .with_usb_storage(dfci_files, "dfci_disk")
             .with_usb_storage(install_files, "install_disk")
-            .with_virtual_drive(virtual_drive)
+            .with_virtual_drive(None if path_to_os else virtual_drive)
             .with_display(not headless)
             .with_network(forward_ports, use_virtio)
             .with_smbios(

--- a/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
@@ -142,7 +142,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             .with_usb_controller()
             .with_usb_mouse()
             .with_usb_keyboard()
-            .with_virtual_drive(virtual_drive)
+            .with_virtual_drive(None if path_to_os else virtual_drive)
             .with_display(not headless)
             .with_network(False)
             .with_smbios(


### PR DESCRIPTION
## Description

Prior to #131, we either passed the virtual drive or we passed the os drive, we did not pass both. While passing both should inherently not be an issue, it is on SBSA. An issue has been filed for it (#135). Regardless, I think it is best to update it back to only passing one or the other.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
