### PR TITLE
Bugfix: QemuCommandBuilder: Remove additional quotations around `file=` arguments

### DIFF
--- a/Platforms/Common/Qemu/QemuCommandBuilder.py
+++ b/Platforms/Common/Qemu/QemuCommandBuilder.py
@@ -73,7 +73,7 @@ class QemuCommandBuilder:
 
         self._rom_path_added = True
         self._logger.debug(f"Setting ROM path to: {rom_dir}")
-        self._args.extend(["-L", f"\"{str(Path(rom_dir))}\""])
+        self._args.extend(["-L", f"{str(Path(rom_dir))}"])
         return self
 
     def with_machine(self, smm_enabled=True, accel=None):
@@ -140,9 +140,9 @@ class QemuCommandBuilder:
             self._args.extend(
                 [
                     "-drive",
-                    f"if=pflash,format=raw,unit=0,file=\"{str(code_fd)}\",readonly=on",
+                    f"if=pflash,format=raw,unit=0,file={str(code_fd)},readonly=on",
                     "-drive",
-                    f"if=pflash,format=raw,unit=1,file=\"{str(vars_fd)}\"",
+                    f"if=pflash,format=raw,unit=1,file={str(vars_fd)}",
                 ]
             )
         elif self._architecture == QemuArchitecture.SBSA:
@@ -151,12 +151,12 @@ class QemuCommandBuilder:
             # Unit 1: QEMU_EFI.fd (readonly)
             if vars_fd:
                 self._args.extend(
-                    ["-drive", f"if=pflash,format=raw,unit=0,file=\"{str(vars_fd)}\""]
+                    ["-drive", f"if=pflash,format=raw,unit=0,file={str(vars_fd)}"]
                 )
             self._args.extend(
                 [
                     "-drive",
-                    f"if=pflash,format=raw,unit=1,file=\"{str(code_fd)}\",readonly=on",
+                    f"if=pflash,format=raw,unit=1,file={str(code_fd)},readonly=on",
                 ]
             )
 
@@ -216,7 +216,7 @@ class QemuCommandBuilder:
             self._args.extend(
                 [
                     "-drive",
-                    f"file=\"{drive_file}\",format={drive_format},media=disk,if=none,id={drive_id}",
+                    f"file={drive_file},format={drive_format},media=disk,if=none,id={drive_id}",
                     "-device",
                     f"usb-storage,bus=usb.0,drive={drive_id}",
                 ]
@@ -225,7 +225,7 @@ class QemuCommandBuilder:
             self._args.extend(
                 [
                     "-drive",
-                    f"file=fat:rw:\"{drive_file}\",format={drive_format},media=disk,if=none,id={drive_id}",
+                    f"file=fat:rw:{drive_file},format={drive_format},media=disk,if=none,id={drive_id}",
                     "-device",
                     f"usb-storage,bus=usb.0,drive={drive_id}",
                 ]
@@ -247,13 +247,13 @@ class QemuCommandBuilder:
 
         if os.path.isfile(virtual_drive):
             self._logger.debug(f"Mounting virtual drive file: {virtual_drive}")
-            self._args.extend(["-drive", f"file=\"{virtual_drive}\",if=virtio"])
+            self._args.extend(["-drive", f"file={virtual_drive},if=virtio"])
         elif os.path.isdir(virtual_drive):
             self._logger.debug(
                 "Mounting virtual drive directory as FAT filesystem: %s", virtual_drive
             )
             self._args.extend(
-                ["-drive", f"file=fat:rw:\"{virtual_drive}\",format=raw,media=disk"]
+                ["-drive", f"file=fat:rw:{virtual_drive},format=raw,media=disk"]
             )
         else:
             self._logger.error(
@@ -292,13 +292,13 @@ class QemuCommandBuilder:
             raise Exception(f"Unknown OS storage type: {path_to_os}")
 
         if storage_format == "iso":
-            self._args.extend(["-cdrom", f"\"{path_to_os}\""])
+            self._args.extend(["-cdrom", f"{path_to_os}"])
         else:
             if self._architecture == QemuArchitecture.Q35:
                 self._args.extend(
                     [
                         "-drive",
-                        f"file=\"{path_to_os}\",format={storage_format},if=none,id=os_nvme",
+                        f"file={path_to_os},format={storage_format},if=none,id=os_nvme",
                         "-device",
                         "nvme,serial=nvme-1,drive=os_nvme",
                     ]
@@ -307,7 +307,7 @@ class QemuCommandBuilder:
                 self._args.extend(
                     [
                         "-drive",
-                        f"file=\"{path_to_os}\",format={storage_format},if=none,id=os_disk",
+                        f"file={path_to_os},format={storage_format},if=none,id=os_disk",
                         "-device",
                         "ahci,id=ahci",
                         "-device",
@@ -464,7 +464,7 @@ class QemuCommandBuilder:
         self._args.extend(
             [
                 "-chardev",
-                f"socket,id=chrtpm,path=\"{tpm_dev}\"",
+                f"socket,id=chrtpm,path={tpm_dev}",
                 "-tpmdev",
                 "emulator,id=tpm0,chardev=chrtpm",
             ]

--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -251,6 +251,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
         rom_path = str(
             SCRIPT_DIR / "QemuPkg" / "Binaries" / "qemu-win_extdep" / "share"
         )
+
         qemu_cmd_builder = (
             QemuCommandBuilder(qemu_exec, QemuArchitecture.Q35)
             .with_cpu(core_count=4)
@@ -386,7 +387,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
 
     (executable, qemu_args) = qemu_cmd_builder.build()
 
-    logging.info("QEMU Command: " + executable)
+    logging.info("QEMU Command: " + executable + " " + " ".join(qemu_args))
     return {
         "build_cmd": build_cmd,
         "build_target": args.build_target,


### PR DESCRIPTION
## Description

Remove additional quotations around file path arguments(`file=`) as they can be escaped by `subprocess.run()` when passing arguments are list of strings and cause QEMU to fail.

This regression is introduced in  https://github.com/OpenDevicePartnership/patina-qemu/commit/662e9d66166d9705b7cb6282842fc6c42c4fac46

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Working in QEMU

## Integration Instructions

NA