### PR TITLE
Nightly OS Boot: Cache prepared images

### DIFF
--- a/.github/workflows/nightly-os-boot.yml
+++ b/.github/workflows/nightly-os-boot.yml
@@ -67,76 +67,76 @@ jobs:
             platform: 'Q35'
             os-artifact: ${{ needs.vars.outputs.ubuntu-x64-artifact }}
             extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
-          # # Q35 RELEASE X64 (Boot to Ubuntu)
-          # - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
-          #   target: 'RELEASE'
-          #   platform: 'Q35'
-          #   os-artifact: ${{ needs.vars.outputs.ubuntu-x64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
-          # # Q35 DEBUG IA32,X64 (Boot to Ubuntu)
-          # - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
-          #   target: 'DEBUG'
-          #   architecture: 'IA32,X64'
-          #   platform: 'Q35'
-          #   os-artifact: ${{ needs.vars.outputs.ubuntu-x64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
-          # # Q35 RELEASE IA32,X64 (Boot to Ubuntu)
-          # - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
-          #   target: 'RELEASE'
-          #   architecture: 'IA32,X64'
-          #   platform: 'Q35'
-          #   os-artifact: ${{ needs.vars.outputs.ubuntu-x64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
-          # # SBSA DEBUG (Boot to Ubuntu)
-          # - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
-          #   target: 'DEBUG'
-          #   platform: 'SBSA'
-          #   os-artifact: ${{ needs.vars.outputs.ubuntu-aarch64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
-          # # SBSA RELEASE (Boot to Ubuntu)
-          # - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
-          #   target: 'RELEASE'
-          #   platform: 'SBSA'
-          #   os-artifact: ${{ needs.vars.outputs.ubuntu-aarch64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
-          # # Q35 DEBUG X64 (Boot to Windows)
-          # - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
-          #   target: 'DEBUG'
-          #   platform: 'Q35'
-          #   os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
-          # # Q35 RELEASE X64 (Boot to Windows)
-          # - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
-          #   target: 'RELEASE'
-          #   platform: 'Q35'
-          #   os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
-          # # Q35 DEBUG IA32,X64 (Boot to Windows)
-          # - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
-          #   target: 'DEBUG'
-          #   architecture: 'IA32,X64'
-          #   platform: 'Q35'
-          #   os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
-          # # Q35 RELEASE IA32,X64 (Boot to Windows)
-          # - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
-          #   target: 'RELEASE'
-          #   architecture: 'IA32,X64'
-          #   platform: 'Q35'
-          #   os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
-          # # SBSA DEBUG (Boot to Windows)
-          # - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
-          #   target: 'DEBUG'
-          #   platform: 'SBSA'
-          #   os-artifact: ${{ needs.vars.outputs.windows-aarch64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
-          # # SBSA RELEASE (Boot to Windows)
-          # - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
-          #   target: 'RELEASE'
-          #   platform: 'SBSA'
-          #   os-artifact: ${{ needs.vars.outputs.windows-aarch64-artifact }}
-          #   extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
+          # Q35 RELEASE X64 (Boot to Ubuntu)
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'RELEASE'
+            platform: 'Q35'
+            os-artifact: ${{ needs.vars.outputs.ubuntu-x64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
+          # Q35 DEBUG IA32,X64 (Boot to Ubuntu)
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'DEBUG'
+            architecture: 'IA32,X64'
+            platform: 'Q35'
+            os-artifact: ${{ needs.vars.outputs.ubuntu-x64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
+          # Q35 RELEASE IA32,X64 (Boot to Ubuntu)
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'RELEASE'
+            architecture: 'IA32,X64'
+            platform: 'Q35'
+            os-artifact: ${{ needs.vars.outputs.ubuntu-x64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
+          # SBSA DEBUG (Boot to Ubuntu)
+          - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
+            target: 'DEBUG'
+            platform: 'SBSA'
+            os-artifact: ${{ needs.vars.outputs.ubuntu-aarch64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
+          # SBSA RELEASE (Boot to Ubuntu)
+          - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
+            target: 'RELEASE'
+            platform: 'SBSA'
+            os-artifact: ${{ needs.vars.outputs.ubuntu-aarch64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2 PATH_TO_SEED=./os-boot-artifacts/seed.iso
+          # Q35 DEBUG X64 (Boot to Windows)
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'DEBUG'
+            platform: 'Q35'
+            os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
+          # Q35 RELEASE X64 (Boot to Windows)
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'RELEASE'
+            platform: 'Q35'
+            os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
+          # Q35 DEBUG IA32,X64 (Boot to Windows)
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'DEBUG'
+            architecture: 'IA32,X64'
+            platform: 'Q35'
+            os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
+          # Q35 RELEASE IA32,X64 (Boot to Windows)
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'RELEASE'
+            architecture: 'IA32,X64'
+            platform: 'Q35'
+            os-artifact: ${{ needs.vars.outputs.windows-x64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
+          # SBSA DEBUG (Boot to Windows)
+          - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
+            target: 'DEBUG'
+            platform: 'SBSA'
+            os-artifact: ${{ needs.vars.outputs.windows-aarch64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
+          # SBSA RELEASE (Boot to Windows)
+          - config: 'Platforms/QemuSbsaPkg/PlatformBuild.py'
+            target: 'RELEASE'
+            platform: 'SBSA'
+            os-artifact: ${{ needs.vars.outputs.windows-aarch64-artifact }}
+            extra-args: PATH_TO_OS=./os-boot-artifacts/image.qcow2
 
     steps:
       # Checkout the repository to the runner or container


### PR DESCRIPTION
## Description

This commit caches the prepared images for OS boot to save time and space. The cache is based off the checksum of the image we are about to prepare. On the ubuntu side, the checksum is directly provided, so we simply download the checksum and attempt to pull the cache. On the windows side, no checksum is provided, so we must still download the image and checksum it manually. This still saves time from needing to actually prepare the images.

This saves space because we change the artifact uploading to only be valid for a single day. However, the cached artifact is valid for however long caches are valid for (I think 90 days?). This means that we cache the prepared images once and can re-distribute it.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran the workflow once to cache the prepared images. Ran a second time to make sure the cached images are properly retrieved. See: https://github.com/Javagedes/patina-qemu/actions/runs/21299364179

## Integration Instructions

N/A
