### PR TITLE
QemuCommandBuilder: Always enable shutdown from guest

### DIFF
--- a/Platforms/Common/Qemu/QemuCommandBuilder.py
+++ b/Platforms/Common/Qemu/QemuCommandBuilder.py
@@ -56,11 +56,13 @@ class QemuCommandBuilder:
                 ["-global", "ICH9-LPC.disable_s3=1"]
             )  # disable S3 sleep state
             self._args.extend(
-                ["-global", f"isa-debugcon.iobase=0x402"]
+                ["-global", "isa-debugcon.iobase=0x402"]
             )  # debug console
             self._args.extend(
                 ["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"]
             )  # debug exit device
+        elif self._architecture == QemuArchitecture.SBSA:
+            self._args.extend(["-semihosting"])
 
     def with_rom_path(self, rom_dir):
         """Set ROM path for QEMU external dependency"""
@@ -571,14 +573,6 @@ class QemuCommandBuilder:
         if port:
             self._monitor_port_added = True
             self._args.extend(["-monitor", f"tcp:{ip}:{port},server,nowait"])
-        return self
-
-    def with_shutdown_from_guest(self, shutdown=True):
-        """Enable shutdown from guest via isa-debug-exit device"""
-
-        if shutdown and self._architecture == QemuArchitecture.Q35:
-            self._args.extend(["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04"])
-
         return self
 
     def with_custom(self, *args):

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -96,7 +96,6 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         qemu_executable_path = QemuRunner.GetStr(env, "QEMU_PATH")
         qemu_ext_dep_dir = QemuRunner.GetStr(env, "QEMU_DIR")
         serial_port = QemuRunner.GetStr(env, "SERIAL_PORT", "50001")
-        shutdown_after_run = QemuRunner.GetBool(env, "SHUTDOWN_AFTER_RUN", False)
         smm_enabled = QemuRunner.GetBuildBool(env, "SMM_ENABLED", True)
         tpm_dev = QemuRunner.GetStr(env, "TPM_DEV")
         virtual_drive = QemuRunner.GetStr(env, "VIRTUAL_DRIVE_PATH")
@@ -158,7 +157,6 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
             .with_gdb_server(gdb_server_port)
             .with_serial_port(serial_port)
             .with_monitor_port(monitor_port)
-            .with_shutdown_from_guest(shutdown_after_run)
         )
 
         if path_to_seed:


### PR DESCRIPTION
## Description

QemuCommandBuilder had a configuration, `with_shutdown_from_guest` which appeared to be a configurable way to allow shutting down qemu from the guest for Q35. However the same exact command line arguments for QEMU were also hardcoded in the `__init__` for the command builder and thus always enabled.

This commit does two things - it removes the unnecessary `with_shutdown_from_guest` command, and it adds the necessary QEMU argument to support shutting down from guest for SBSA also.

The `SHUTDOWN_AFTER_RUN` environment variable is still used by the build script. This variable is used to generate a startup nsh with a shutdown command at the end of the script. We are only removing its usage from the QEMU Command builder, as it was effectively doing nothing.

Please note that this will not actually cause shutdowns with the current binary. https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/pull/105 must be merged and a release performed to result in QEMU shutting down in error when a test fails.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated that both SBSA and Q35 will shutdown and return an error value when a patina test fails.

## Integration Instructions

N/A
