### PR TITLE
Publish Firmware on Repo Release [Rebase & FF]

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -285,6 +285,14 @@ jobs:
             capture.json
             validator_output.txt
 
+  publish-release-assets:
+    needs: build
+    if: github.event_name == 'release'
+    uses: ./.github/workflows/publish-release-assets.yml
+    with:
+      release-tag: ${{ github.event.release.tag_name }}
+    secrets: inherit
+
   # A final job to indicate that all builds are complete. This allows the github required checks to
   # be targeted at a single job, instead of all the jobs in the matrix, which may change over time.
   finalize:

--- a/.github/workflows/publish-release-assets.yml
+++ b/.github/workflows/publish-release-assets.yml
@@ -1,0 +1,95 @@
+# Workflow that publishes release assets to GitHub releases in patina-qemu.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: Publish Release Assets
+
+on:
+  workflow_call:
+    inputs:
+      release-tag:
+        description: Release tag name to upload assets to.
+        required: true
+        type: string
+
+jobs:
+  publish-release-assets:
+    name: Publish Release Assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
+          private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: ${{ runner.temp }}/release-artifacts
+
+      - name: Stage the zip contents
+        shell: python
+        run: |
+          from pathlib import Path
+          import shutil
+
+          artifacts_root = Path(r"${{ runner.temp }}/release-artifacts")
+          staging_root = Path(r"${{ runner.temp }}/release-staging")
+          q35_stage = staging_root / "Q35"
+          sbsa_stage = staging_root / "SBSA"
+
+          q35_stage.mkdir(parents=True, exist_ok=True)
+          sbsa_stage.mkdir(parents=True, exist_ok=True)
+
+          for artifact_dir in artifacts_root.glob("release-bin-*"):
+            name = artifact_dir.name
+
+            if name.startswith("release-bin-Q35-"):
+              variant = name.removeprefix("release-bin-Q35-")
+              destination = q35_stage / variant
+            elif name.startswith("release-bin-SBSA-"):
+              variant = name.removeprefix("release-bin-SBSA-")
+              destination = sbsa_stage / variant
+            else:
+              continue
+
+            destination.mkdir(parents=True, exist_ok=True)
+
+            for firmware_file in artifact_dir.rglob("*.fd"):
+              shutil.copy2(firmware_file, destination / firmware_file.name)
+
+      - name: Create the zip files
+        shell: python
+        run: |
+          from pathlib import Path
+          from zipfile import ZIP_DEFLATED, ZipFile
+
+          staging_root = Path(r"${{ runner.temp }}/release-staging")
+          assets_root = Path(r"${{ runner.temp }}/release-assets")
+          tag_name = r"${{ inputs.release-tag }}"
+
+          assets_root.mkdir(parents=True, exist_ok=True)
+
+          def create_zip(source_dir: Path, destination_zip: Path) -> None:
+            with ZipFile(destination_zip, mode="w", compression=ZIP_DEFLATED) as archive:
+              for item in source_dir.rglob("*"):
+                if item.is_file():
+                  archive.write(item, arcname=item.relative_to(staging_root))
+
+          create_zip(staging_root / "Q35", assets_root / f"patina-qemu-q35-{tag_name}.zip")
+          create_zip(staging_root / "SBSA", assets_root / f"patina-qemu-sbsa-{tag_name}.zip")
+
+      - name: Upload zip files to the release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release upload "${{ inputs.release-tag }}" "${{ runner.temp }}/release-assets/patina-qemu-q35-${{ inputs.release-tag }}.zip" --clobber --repo "${GH_REPO}"
+          gh release upload "${{ inputs.release-tag }}" "${{ runner.temp }}/release-assets/patina-qemu-sbsa-${{ inputs.release-tag }}.zip" --clobber --repo "${GH_REPO}"


### PR DESCRIPTION
## Description

Attaches Q35 and SBSA binaries to the repo GitHub release upon publication (GitHub release draft published). This allows an historical record of pre-built binaries at that release point, in addition to making the binaries available to automation workflows.

---

### Changes

**.github/platform-ci.yml: Remove architecture from the matrix**

The architecture field is unused in the current platform CI workflow.

Remove it to simplify the workflow. It can be addeed back in the
future if needed.

> Note: I can add this back if preferred. I didn't see an obvious need
> for it when reviewing the workflow.

---

**platform-ci.yml: Publish platform binaries to workflow artifacts**

On a release trigger, upload the firmware binaries built as artifacts
to the workflow run so they can be picked up by the release workflow
and published as release assets.

---

**.github: Add repo release workflow**

Adds a new workflow (`publish-release-assets.yml`) that stages the
platform firmware binaries from a build and creates zip files for
distribution. The zip file is then uploaded as an asset to the GitHub
release corresponding to the tag used for the build.

The new workflow is invoked from the existing `platform-ci.yml`
workflow after the build job completes, but only when a release event
occurs.

---

> This is the first of a few changes to place binary patching into the CI
> process and bring that automation to the PR gates in the patin repo.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Published release on fork with the workflow. Verified binaries in the release.
  - Test release: https://github.com/makubacki/patina-qemu/releases/tag/v0.0.3
  - Corresponding workflow run: https://github.com/makubacki/patina-qemu/actions/runs/21972504813

## Integration Instructions

- After this repo begins making releases with this change, use the firmware uploaded as a release asset in your workflows if beneficial.