### PR TITLE
Build and Run Script Automation Updates [Rebase & FF]

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -52,6 +52,7 @@ def _parse_arguments() -> argparse.Namespace:
         --platform (str): QEMU platform such as Q35. Default is "Q35".
         --toolchain (str): Toolchain to use for building. Default is "VS2022".
         --features (str): Feature set to pass to patina-dxe-core-qemu build
+        --core-count (int): Number of QEMU CPU cores. Default is 2.
 
     Returns:
         argparse.Namespace: Parsed command-line arguments.
@@ -178,6 +179,12 @@ def _parse_arguments() -> argparse.Namespace:
         help="Port to use for QEMU monitor communication.",
     )
     parser.add_argument(
+        "--core-count",
+        type=int,
+        default=2,
+        help="Number of QEMU CPU cores.",
+    )
+    parser.add_argument(
         "--headless",
         action="store_true",
         default=False,
@@ -293,7 +300,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
 
         qemu_cmd_builder = (
             QemuCommandBuilder(qemu_exec, QemuArchitecture.Q35)
-            .with_cpu(core_count=4)
+            .with_cpu(core_count=args.core_count)
             .with_machine()
             .with_memory(8192 if args.os else 2048)
             .with_firmware(code_fd, var_store)
@@ -393,7 +400,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
 
         qemu_cmd_builder = (
             QemuCommandBuilder(qemu_exec, QemuArchitecture.SBSA)
-            .with_cpu(core_count=4)
+            .with_cpu(core_count=args.core_count)
             .with_machine()
             .with_memory(8192 if args.os else 2048)
             .with_firmware(code_fd, var_store)


### PR DESCRIPTION
## Description

Series of commits to support automation using the `build_and_rust_rust_binary.py` script.

Supports:

- https://github.com/OpenDevicePartnership/patina-qemu/issues/119
- https://github.com/OpenDevicePartnership/patina/issues/1313

---

build_and_run_rust_binary.py: Add headless parameter

Adds a `--headless` parameter to run QEMU without display. Useful
for running the script in CI.

---

build_and_run_rust_binary.py: Add a --no-build flag

Adds an option to skip the build step and directly run the binary.

This is useful for testing against changes in the underlying firmware
ROM image without having to rebuild the Rust binary every time or
quickly test changes in the script itself.

---

build_and_run_rust_binary.py: Add --shutdown-after-run option

Adds the `--shutdown-after-run` flag which will go through the
process of mounting the virtual drive with the `startup.nsh` to
issue the `reset -s` command in shell to shutdown.

Useful for automation.

Core functionality is reused from the QEMU command builder.

---

buid_and_run_rust_binary.py: Ignore non-zero QEMU return codes

Matches common return codes treated as success elsewhere for QEMU.

For example:
https://github.com/OpenDevicePartnership/patina-qemu/blob/c198a9011e7e92717c794b466d636a7abf2781d9/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py#L167

---

build_and_run_rust_binary.py: Add --core-count option

Adds the `--core-count` flag which allows specifying the number of
QEMU CPU cores to use.

Default is `2` to align with the `QEMU_CORE_NUM` variable passed
in CI builds that ultimately sets the `PcdCpuMaxLogicalProcessorNumber`
value in the released firmware image.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run `build_and_rust_binary.py` with all new commands present and absent and check script behavior

## Integration Instructions

- N/A