### PR TITLE
Q35: Remove BdsDxe, now provided by Patina BootDispatcher

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -951,10 +951,7 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
   MdeModulePkg/Universal/Metronome/Metronome.inf
   PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcatRealTimeClockRuntimeDxe.inf
   MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.inf
-  MdeModulePkg/Universal/BdsDxe/BdsDxe.inf {
-    <PcdsDynamicExDefault>
-      gMsGraphicsPkgTokenSpaceGuid.PcdPostBackgroundColoringSkipCount|0
-  }
+  # BdsDxe removed — BDS arch protocol now provided by Patina BootDispatcher in the Rust DXE Core
 
   QemuQ35Pkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf {
     <LibraryClasses>

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -339,7 +339,7 @@ INF  MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsoleDxe.inf
 INF  MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
 !endif
 INF  MdeModulePkg/Universal/DriverHealthManagerDxe/DriverHealthManagerDxe.inf
-INF  MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+# BdsDxe removed — BDS arch protocol now provided by Patina BootDispatcher in the Rust DXE Core
 # MU_CHANGE
 #INF  MdeModulePkg/Application/UiApp/UiApp.inf
 INF  QemuQ35Pkg/QemuKernelLoaderFsDxe/QemuKernelLoaderFsDxe.inf


### PR DESCRIPTION
## Description

Remove TianoCore BdsDxe from Q35 build. BDS arch protocol is now provided by Patina BootDispatcher in the Rust DXE Core.

Depends on OpenDevicePartnership/patina#1333 and corresponding patina-dxe-core-qemu change.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

End-to-end boot on QEMU Q35 with UEFI Shell on GPT/NVMe disk. BDS phase handled by Patina BootDispatcher. Clean shutdown.

## Integration Instructions

Must be paired with patina-dxe-core-qemu Q35 boot orchestrator integration (https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/pull/130)