### PR TITLE
build_and_run_rust_binary.py: Add --do-not-exit-on-patina-test-failure

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -172,6 +172,12 @@ def _parse_arguments() -> argparse.Namespace:
         "--patina-dxe-core-repo.",
     )
     parser.add_argument(
+        "--do-not-exit-on-patina-test-failure",
+        action="store_true",
+        default=False,
+        help="Pass --do-not-exit-on-patina-test-failure to not exit QEMU when a Patina test fails.",
+    )
+    parser.add_argument(
         "--monitor-port",
         "-m",
         type=int,
@@ -437,9 +443,14 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
     else:
         raise ValueError(f"Unsupported platform: {args.platform}")
 
+    pass_through_args = []
     if args.features is not None:
-        build_cmd.append("--features")
-        build_cmd.append(str(args.features))
+        pass_through_args.extend(["--features", str(args.features)])
+    if args.do_not_exit_on_patina_test_failure:
+        pass_through_args.extend(["--exclude-features", "exit_on_patina_test_failure"])
+    if pass_through_args:
+        build_cmd.append("--")
+        build_cmd.extend(pass_through_args)
 
     (executable, qemu_args) = qemu_cmd_builder.build()
 


### PR DESCRIPTION
## Description

Supports https://github.com/OpenDevicePartnership/patina-devops/issues/100

Adds a new cmdline argument `--do-not-exit-on-patina-test-failure` that will pass `--exclude-features exit_on_patina_test_failure` to the patina-dxe-core-qemu cargo make build command.

This is specially added to support patina repository CI flows where Patina tests are run and errors are reported/captured but PRs are not blocked. Other use cases such as patina-dxe-core-qemu and patina-qemu CI and local development are expected to continue using the default behavior of exiting QEMU when a Patina test fails, so the default behavior is not changed by this commit.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verify a Patina test failure exits with:

  `python .\build_and_run_rust_binary.py -p Q35`

- Verify a Patina test failure does not exit with:

  `python .\build_and_run_rust_binary.py -p Q35 --do-not-exit-on-patina-test-failure`

## Integration Instructions

- N/A
