### PR TITLE
.github: remove `tool-chain` input usage

### DIFF
--- a/.github/workflows/nightly-adv-logger.yml
+++ b/.github/workflows/nightly-adv-logger.yml
@@ -34,7 +34,6 @@ jobs:
     timeout-minutes: 30
 
     env:
-      TOOL_CHAIN: ${{ needs.vars.outputs.linux-toolchain }}
       STARTUP_NSH_PATH: './STARTUP.NSH'
       LOG_FILE: 'ADV_LOGS.TXT'
 
@@ -92,7 +91,6 @@ jobs:
           platform-config: ${{ matrix.config }}
           platform-name: ${{ matrix.platform }}
           target: ${{ matrix.target }}
-          tool-chain: ${{ env.TOOL_CHAIN }}
           stuart-args: 'QEMU_HEADLESS=TRUE STARTUP_NSH="${{ env.STARTUP_NSH_PATH }}" SHUTDOWN_AFTER_RUN=TRUE FILE_REGEX=*AdvancedLogDumper.efi'
 
       - name: Run
@@ -102,7 +100,6 @@ jobs:
           platform-config: ${{ matrix.config }}
           platform-name: ${{ matrix.platform }}
           target: ${{ matrix.target }}
-          tool-chain: ${{ env.TOOL_CHAIN }}
           stuart-args: 'QEMU_HEADLESS=TRUE STARTUP_NSH="${{ env.STARTUP_NSH_PATH }}" SHUTDOWN_AFTER_RUN=TRUE FILE_REGEX=*AdvancedLogDumper.efi'
 
       # Extracts and validates the log dump from AdvancedLogDumper dumps logs from PEI and DXE
@@ -185,5 +182,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: build-logs-${{ matrix.platform }}-${{ matrix.target }}-${{ env.TOOL_CHAIN }}
+          name: build-logs-${{ matrix.platform }}-${{ matrix.target }}
           path: ${{ steps.build-platform.outputs.log-path }}

--- a/.github/workflows/nightly-os-boot.yml
+++ b/.github/workflows/nightly-os-boot.yml
@@ -58,7 +58,6 @@ jobs:
 
     env:
       OS_BOOT_ARTIFACTS_PATH: ./os-boot-artifacts
-      TOOL_CHAIN: ${{ needs.vars.outputs.linux-toolchain }}
 
     strategy:
       fail-fast: false
@@ -208,7 +207,6 @@ jobs:
           platform-config: ${{ matrix.config }}
           platform-name: ${{ matrix.platform }}
           target: ${{ matrix.target }}
-          tool-chain: ${{ env.TOOL_CHAIN }}
           stuart-args: 'QEMU_HEADLESS=TRUE ${{ matrix.extra-args }} OS_BOOT_DEVICE=${{ matrix.os-boot-device}}'
 
       - name: Run
@@ -218,7 +216,6 @@ jobs:
           platform-config: ${{ matrix.config }}
           platform-name: ${{ matrix.platform }}
           target: ${{ matrix.target }}
-          tool-chain: ${{ env.TOOL_CHAIN }}
           stuart-args: 'QEMU_HEADLESS=TRUE ${{ matrix.extra-args }} OS_BOOT_DEVICE=${{ matrix.os-boot-device}}'
 
       - name: Publish Logs
@@ -226,5 +223,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           # Specify architecture if it is not empty
-          name: build-logs-${{ matrix.os-boot-device }}-${{ matrix.platform }}-${{ matrix.target }}-${{ env.TOOL_CHAIN }}-${{ contains(matrix.os-artifact, 'windows') && 'windows' || 'ubuntu' }}
+          name: build-logs-${{ matrix.os-boot-device }}-${{ matrix.platform }}-${{ matrix.target }}-${{ contains(matrix.os-artifact, 'windows') && 'windows' || 'ubuntu' }}
           path: ${{ steps.build-platform.outputs.log-path }}


### PR DESCRIPTION
## Description

Removes `tool-chain` input from any usage of the `build-platform` action as it was removed

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ran nightly tests on this branch

## Integration Instructions

N/A
