### PR TITLE
TPM Updates for Q35 & SBSA Including TpmTestApp

### DIFF
--- a/.github/workflows/q35-tpm.yml
+++ b/.github/workflows/q35-tpm.yml
@@ -1,0 +1,103 @@
+# A workflow to build and test the Q35 platform with TPM enabled.
+#
+##
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+name: "Q35 TPM"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: "q35-tpm-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+
+  vars:
+    name: Get Repository Constants
+    uses: OpenDevicePartnership/patina-devops/.github/workflows/qemu-constants.yml@main
+
+  build:
+    name: Build Q35 TPM ${{ matrix.target }}
+    needs: vars
+    runs-on: ubuntu-latest
+
+    container:
+      image: ${{ needs.vars.outputs.container-image }}
+      options: --security-opt seccomp=unconfined
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'DEBUG'
+            platform: 'Q35'
+          - config: 'Platforms/QemuQ35Pkg/PlatformBuild.py'
+            target: 'RELEASE'
+            platform: 'Q35'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Configure Git
+        uses: ./.github/actions/configure-git
+
+      - name: Install dependencies
+        run: pip install -r pip-requirements.txt
+
+      - name: Install swtpm
+        run: |
+          apt-get update
+          apt-get install -y swtpm swtpm-tools
+
+      - name: Setup TPM state directory
+        run: mkdir -p /tmp/mytpm1
+
+      - name: Redirect Hafnium Submodule URLs
+        uses: ./.github/actions/redirect-hafnium-urls
+
+      - name: Prepare and Build Q35 TPM ${{ matrix.target }}
+        id: build-platform
+        uses: ./.github/actions/build-platform
+        with:
+          command: 'build'
+          platform-config: ${{ matrix.config }}
+          platform-name: ${{ matrix.platform }}
+          target: ${{ matrix.target }}
+          stuart-args: 'SHUTDOWN_AFTER_RUN=TRUE FILE_REGEX=*TestApp*.efi RUN_TESTS=TRUE QEMU_HEADLESS=TRUE BLD_*_TPM_ENABLE=TRUE TPM_DEV=/tmp/mytpm1/swtpm-sock'
+
+      - name: Run Q35 TPM ${{ matrix.target }}
+        timeout-minutes: 15
+        uses: ./.github/actions/build-platform
+        with:
+          command: 'flash'
+          platform-config: ${{ matrix.config }}
+          platform-name: ${{ matrix.platform }}
+          target: ${{ matrix.target }}
+          stuart-args: 'SHUTDOWN_AFTER_RUN=TRUE FILE_REGEX=*TestApp*.efi RUN_TESTS=TRUE QEMU_HEADLESS=TRUE BLD_*_TPM_ENABLE=TRUE TPM_DEV=/tmp/mytpm1/swtpm-sock'
+
+      - name: Publish Logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-logs-Q35-TPM-${{ matrix.target }}
+          path: ${{ steps.build-platform.outputs.log-path }}
+
+  finalize:
+    name: Finalize Q35 TPM
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Finish
+        run: echo "All Q35 TPM builds complete"

--- a/Platforms/QemuQ35Pkg/PlatformPei/Platform.c
+++ b/Platforms/QemuQ35Pkg/PlatformPei/Platform.c
@@ -193,6 +193,7 @@ MemMapInitialization (
   // 0xFED00400    gap                          111 KB
   // 0xFED1C000    gap (PIIX4) / RCRB (ICH9)     16 KB
   // 0xFED20000    gap                          896 KB
+  // 0xFED40000    TPM - Locality0                4 KB
   // 0xFEE00000    LAPIC                          1 MB
   //
   PciSize = 0xFC000000 - PciBase;
@@ -204,6 +205,7 @@ MemMapInitialization (
 
   AddIoMemoryBaseSizeHob (0xFEC00000, SIZE_4KB);
   AddIoMemoryBaseSizeHob (0xFED00000, SIZE_4KB);
+  AddIoMemoryBaseSizeHob (0xFED40000, SIZE_4KB);
   if (mHostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID) {
     AddIoMemoryBaseSizeHob (ICH9_ROOT_COMPLEX_BASE, SIZE_16KB);
     //

--- a/Platforms/QemuQ35Pkg/PlatformPei/Platform.c
+++ b/Platforms/QemuQ35Pkg/PlatformPei/Platform.c
@@ -205,7 +205,12 @@ MemMapInitialization (
 
   AddIoMemoryBaseSizeHob (0xFEC00000, SIZE_4KB);
   AddIoMemoryBaseSizeHob (0xFED00000, SIZE_4KB);
+
+  // Only generate this HOB if TPM is enabled
+  #ifdef TPM_ENABLE
   AddIoMemoryBaseSizeHob (0xFED40000, SIZE_4KB);
+  #endif
+
   if (mHostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID) {
     AddIoMemoryBaseSizeHob (ICH9_ROOT_COMPLEX_BASE, SIZE_16KB);
     //

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -11,6 +11,7 @@ import os
 import re
 import io
 import shutil
+import threading
 from edk2toolext.environment.plugintypes import uefi_helper_plugin
 from edk2toollib import utility_functions
 
@@ -71,6 +72,23 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
     @staticmethod
     def GetStr(env, key: str, default: str | None = None) -> str | None:
         return env.GetValue(key) or default
+
+    @staticmethod
+    def RunThread(env):
+        """Runs TPM in a separate thread"""
+        tpm_path = env.GetValue("TPM_DEV")
+        if tpm_path is None:
+            logging.critical("TPM Path Invalid")
+            return
+
+        tpm_cmd = "swtpm"
+        tpm_args = f"socket --tpmstate dir={'/'.join(tpm_path.rsplit('/', 1)[:-1])} --ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
+
+        # Start the TPM emulator in a separate thread
+        ret = utility_functions.RunCmd(tpm_cmd, tpm_args)
+        if ret != 0:
+            logging.critical("Failed to start TPM emulator.")
+            return
 
     @staticmethod
     def Runner(env):
@@ -159,6 +177,13 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
 
         (executable, args) = qemu_cmd_builder.build()
 
+        thread = None
+        if tpm_dev:
+            # also spawn the TPM emulator on a different thread
+            logging.critical("Starting TPM emulator in a different thread.")
+            thread = threading.Thread(target=QemuRunner.RunThread, args=(env,))
+            thread.start()
+
         # Run QEMU
         ret = utility_functions.RunCmd(executable, str.join(" ", args))
 
@@ -178,4 +203,8 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         elif os.name != "nt":
             # Linux version of QEMU will mess with the print if its run failed, let's just restore it anyway
             utility_functions.RunCmd("stty", "sane", capture=False)
+
+        if thread is not None:
+            logging.critical("Terminate TPM emulator by using Crtl + C now!")
+            thread.join()
         return ret

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -252,9 +252,8 @@
   Tcg2PhysicalPresenceLib |QemuPkg/Library/Tcg2PhysicalPresenceLibNull/DxeTcg2PhysicalPresenceLib.inf
   Tpm2HelpLib             |SecurityPkg/Library/Tpm2HelpLib/Tpm2HelpLib.inf
 !if $(TPM_ENABLE) == TRUE
-  Tcg2PhysicalPresenceLib |QemuPkg/Library/Tcg2PhysicalPresenceLibQemu/DxeTcg2PhysicalPresenceLib.inf
+  Tcg2PhysicalPresenceLib |SecurityPkg/Library/DxeTcg2PhysicalPresenceMinimumLib/DxeTcg2PhysicalPresenceMinimumLib.inf
   TpmMeasurementLib       |SecurityPkg/Library/DxeTpmMeasurementLib/DxeTpmMeasurementLib.inf
-  Tpm2DebugLib            |SecurityPkg/Library/Tpm2DebugLib/Tpm2DebugLibSimple.inf
 !endif
 
   # Shell Libraries
@@ -384,9 +383,8 @@
   PolicyLib                  |PolicyServicePkg/Library/PeiPolicyLib/PeiPolicyLib.inf
   SmmRelocationLib           |QemuQ35Pkg/Library/SmmRelocationLib/SmmRelocationLib.inf
 !if $(TPM_ENABLE) == TRUE
-  Tpm12DeviceLib             |SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12DeviceLibDTpm.inf
   Tpm2DeviceLib              |SecurityPkg/Library/Tpm2DeviceLibDTpm/Tpm2DeviceLibDTpm.inf
-  Tcg2PreUefiEventLogLib     |QemuPkg/Library/QemuPreUefiEventLogLibNull/QemuPreUefiEventLogLibNull.inf
+  Tcg2PreUefiEventLogLib     |SecurityPkg/Library/Tcg2PreUefiEventLogLibNull/Tcg2PreUefiEventLogLibNull.inf
 !endif
   RngLib                     |MdePkg/Library/PeiRngLib/PeiRngLib.inf
 
@@ -437,6 +435,7 @@
 [LibraryClasses.common.UEFI_APPLICATION]
   CheckHwErrRecHeaderLib|MsWheaPkg/Library/CheckHwErrRecHeaderLib/CheckHwErrRecHeaderLib.inf
   FlatPageTableLib|UefiTestingPkg/Library/FlatPageTableLib/FlatPageTableLib.inf
+  IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
 
 [LibraryClasses.common.DXE_DRIVER]
   PlatformBootManagerLib|MsCorePkg/Library/PlatformBootManagerLib/PlatformBootManagerLib.inf
@@ -447,7 +446,6 @@
   CapsuleLib|MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
   PolicyLib|PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
 !if $(TPM_ENABLE) == TRUE
-  Tpm12DeviceLib|SecurityPkg/Library/Tpm12DeviceLibTcg/Tpm12DeviceLibTcg.inf
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibTcg2/Tpm2DeviceLibTcg2.inf
 !endif
 
@@ -744,7 +742,7 @@
   # unknown) workloads / boot paths.
   #
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiACPIMemoryNVS|0x80
-  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiACPIReclaimMemory|0x20
+  gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiACPIReclaimMemory|0x2B
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiReservedMemoryType|0x510
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesCode|0x100
   gEmbeddedTokenSpaceGuid.PcdMemoryTypeEfiRuntimeServicesData|0x700
@@ -788,7 +786,7 @@
   gUefiQemuQ35PkgTokenSpaceGuid.PcdPciMmio64Size|0x800000000
 
   # Limit to SHA256 for now.
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0x00002
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2HashMask|0x02
 
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvStoreReserved|0
 
@@ -835,9 +833,11 @@
   !endif
 
 [PcdsDynamicHii]
-!if $(TPM_ENABLE) == TRUE && $(TPM_CONFIG_ENABLE) == TRUE
+!if $(TPM_ENABLE) == TRUE
+  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x8|4|NV,BS
+!endif
+!if $(TPM_CONFIG_ENABLE) == TRUE
   gEfiSecurityPkgTokenSpaceGuid.PcdTcgPhysicalPresenceInterfaceVer|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x0|"1.3"|NV,BS
-  gEfiSecurityPkgTokenSpaceGuid.PcdTpm2AcpiTableRev|L"TCG2_VERSION"|gTcg2ConfigFormSetGuid|0x8|3|NV,BS
 !endif
 
 ################################################################################
@@ -914,7 +914,6 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
       # Only TPM 2.0 is supported by the feature
       NULL|TpmTestingPkg/Overrides/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.inf
 !else
-      NULL|SecurityPkg/Library/DxeTpmMeasureBootLib/DxeTpmMeasureBootLib.inf
       NULL|SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.inf
 !endif
 !endif
@@ -1308,6 +1307,9 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
       MfciRetrievePolicyLib|MfciPkg/Library/MfciRetrievePolicyLibViaHob/MfciRetrievePolicyLibViaHob.inf
       MfciDeviceIdSupportLib|MfciPkg/Library/MfciDeviceIdSupportLibSmbios/MfciDeviceIdSupportLibSmbios.inf
   }
+
+  # TPM test application to test PCR bank operations via TCG2 Protocol
+  SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
 
 !include TpmTestingPkg/TpmReplay.dsc.inc
 

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1308,8 +1308,14 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
       MfciDeviceIdSupportLib|MfciPkg/Library/MfciDeviceIdSupportLibSmbios/MfciDeviceIdSupportLibSmbios.inf
   }
 
+# The TpmTestApp can run without TPM enabled. It will report that the
+# Tcg2Protocol was not installed, however, it really isn't meant to run
+# without TPM enabled. This prevents an issue in CI where all TestApps
+# are auto included to run.
+!if $(TPM_ENABLE) == TRUE
   # TPM test application to test PCR bank operations via TCG2 Protocol
   SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+#endif
 
 !include TpmTestingPkg/TpmReplay.dsc.inc
 

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1310,11 +1310,13 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
 
 # The TpmTestApp can run without TPM enabled. It will report that the
 # Tcg2Protocol was not installed, however, it really isn't meant to run
-# without TPM enabled. This prevents an issue in CI where all TestApps
-# are auto included to run.
+# without TPM enabled. TPM_TEST_APP_ENABLE prevents an issue in CI where
+# all TestApps are auto included to run.
 !if $(TPM_ENABLE) == TRUE
+!if $(TPM_TEST_APP_ENABLE) == TRUE
   # TPM test application to test PCR bank operations via TCG2 Protocol
   SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+!endif
 !endif
 
 !include TpmTestingPkg/TpmReplay.dsc.inc
@@ -1427,6 +1429,13 @@ QemuQ35Pkg/ResetVector/ResetVector.inf
     DEFINE PERFORMANCE_OPTIONS = -DPERF_TRACE_ENABLE=1
   !else
     DEFINE PERFORMANCE_OPTIONS =
+  !endif
+
+  !if $(TPM_ENABLE) == TRUE
+  #
+  # Enable TPM support
+  #
+  *_CLANGPDB_*_CC_FLAGS = -DTPM_ENABLE
   !endif
 
   # Exception tables are required for stack walks in the debugger.

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1315,7 +1315,7 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
 !if $(TPM_ENABLE) == TRUE
   # TPM test application to test PCR bank operations via TCG2 Protocol
   SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
-#endif
+!endif
 
 !include TpmTestingPkg/TpmReplay.dsc.inc
 

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -460,7 +460,9 @@ INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !endif
 !endif
 
+!if $(TPM_ENABLE) == TRUE
 INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+!endif
 
 INF  AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf
 INF  MsCorePkg/Universal/StatusCodeHandler/Serial/Dxe/SerialStatusCodeHandlerDxe.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -461,7 +461,9 @@ INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !endif
 
 !if $(TPM_ENABLE) == TRUE
+!if $(TPM_TEST_APP_ENABLE) == TRUE
 INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+!endif
 !endif
 
 INF  AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -460,6 +460,8 @@ INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !endif
 !endif
 
+INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+
 INF  AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf
 INF  MsCorePkg/Universal/StatusCodeHandler/Serial/Dxe/SerialStatusCodeHandlerDxe.inf
 INF  MsCorePkg/MuCryptoDxe/MuCryptoDxe.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1237,8 +1237,14 @@
   # FF-A test application to test the FF-A interface
   FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.inf
 
+# The TpmTestApp can run without TPM enabled. It will report that the
+# Tcg2Protocol was not installed, however, it really isn't meant to run
+# without TPM enabled. This prevents an issue in CI where all TestApps
+# are auto included to run.
+!if $(TPM2_ENABLE) == TRUE
   # TPM test application to test PCR bank operations via TCG2 Protocol
   SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+!endif
 
 ###################################################################################################
 #

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1239,11 +1239,13 @@
 
 # The TpmTestApp can run without TPM enabled. It will report that the
 # Tcg2Protocol was not installed, however, it really isn't meant to run
-# without TPM enabled. This prevents an issue in CI where all TestApps
-# are auto included to run.
+# without TPM enabled. TPM_TEST_APP_ENABLE prevents an issue in CI where
+# all TestApps are auto included to run.
 !if $(TPM2_ENABLE) == TRUE
+!if $(TPM_TEST_APP_ENABLE) == TRUE
   # TPM test application to test PCR bank operations via TCG2 Protocol
   SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+!endif
 !endif
 
 ###################################################################################################

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -454,6 +454,7 @@
   PerformanceLib|MdeModulePkg/Library/DxePerformanceLib/DxePerformanceLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   HiiLib|MdeModulePkg/Library/UefiHiiLib/UefiHiiLib.inf
+  IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
 
 #########################################
 # Advanced Logger Libraries
@@ -1235,6 +1236,9 @@
 
   # FF-A test application to test the FF-A interface
   FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.inf
+
+  # TPM test application to test PCR bank operations via TCG2 Protocol
+  SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
 
 ###################################################################################################
 #

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -278,7 +278,9 @@ READ_LOCK_STATUS   = TRUE
   INF ShellPkg/DynamicCommand/VariablePolicyDynamicCommand/VariablePolicyDynamicCommand.inf
   INF QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
 
+!if $(TPM2_ENABLE) == TRUE
   INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+!endif
 
   INF MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerDxe.inf
   INF MsGraphicsPkg/RenderingEngineDxe/RenderingEngineDxe.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -279,7 +279,9 @@ READ_LOCK_STATUS   = TRUE
   INF QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
 
 !if $(TPM2_ENABLE) == TRUE
+!if $(TPM_TEST_APP_ENABLE) == TRUE
   INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+!endif
 !endif
 
   INF MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerDxe.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -278,6 +278,8 @@ READ_LOCK_STATUS   = TRUE
   INF ShellPkg/DynamicCommand/VariablePolicyDynamicCommand/VariablePolicyDynamicCommand.inf
   INF QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
 
+  INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+
   INF MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerDxe.inf
   INF MsGraphicsPkg/RenderingEngineDxe/RenderingEngineDxe.inf
   INF MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardDxe.inf

--- a/QemuPkg/Library/DeviceBootManagerLibQemu/DeviceBootManagerLib.c
+++ b/QemuPkg/Library/DeviceBootManagerLibQemu/DeviceBootManagerLib.c
@@ -27,6 +27,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MsPlatformDevicesLib.h>
 #include <Library/PcdLib.h>
 #include <Library/PrintLib.h>
+#include <Library/Tcg2PhysicalPresenceLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
@@ -328,6 +329,8 @@ DeviceBootManagerAfterConsole (
       Status = TpmPp->PromptForConfirmation (TpmPp);
       DEBUG ((DEBUG_ERROR, "%a: Unexpected return from Tpm Physical Presence. Code=%r\n", __func__, Status));
     }
+
+    Tcg2PhysicalPresenceLibProcessRequest (NULL);
   }
 
   return GetPlatformConnectList ();

--- a/QemuPkg/Library/DeviceBootManagerLibQemu/DeviceBootManagerLib.inf
+++ b/QemuPkg/Library/DeviceBootManagerLibQemu/DeviceBootManagerLib.inf
@@ -25,6 +25,7 @@
   MsCorePkg/MsCorePkg.dec
   MsGraphicsPkg/MsGraphicsPkg.dec
   PcBdsPkg/PcBdsPkg.dec
+  SecurityPkg/SecurityPkg.dec
   ShellPkg/ShellPkg.dec
   MsWheaPkg/MsWheaPkg.dec
 
@@ -44,6 +45,7 @@
   MsBootManagerSettingsLib
   BootGraphicsLib
   GraphicsConsoleHelperLib
+  Tcg2PhysicalPresenceLib
 
 [Guids]
   gUefiShellFileGuid

--- a/docs/TPM/TpmQemuQ35.md
+++ b/docs/TPM/TpmQemuQ35.md
@@ -1,0 +1,415 @@
+# TPM on QEMU Q35
+
+This document describes the TPM 2.0 architecture for the QEMU Q35 platform. Q35 uses a
+direct CRB/FIFO path between firmware and the TPM device.
+
+## Table of Contents
+
+- [Build Configuration](#build-configuration)
+- [Platform Memory Layout](#platform-memory-layout)
+- [Architecture Overview](#architecture-overview)
+- [TPM Device Library Stack](#tpm-device-library-stack)
+- [Hash Library Architecture](#hash-library-architecture)
+- [Physical Presence Interface](#physical-presence-interface)
+- [swtpm Setup](#swtpm-setup)
+- [Communication Flow](#communication-flow)
+- [PCDs Reference](#pcds-reference)
+
+## Build Configuration
+
+The TPM is disabled by default. To enable it, pass the build define and provide the swtpm
+socket path or provide it in a BuildConfig.conf file placed at the root level of the repo:
+
+```bash
+stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
+  BLD_*_TPM_ENABLE=TRUE \
+  TPM_DEV=/tmp/mytpm1/swtpm-sock
+```
+
+The following defines control TPM behavior in `QemuQ35Pkg.dsc`:
+
+| Define | Default | Purpose |
+|--------|---------|---------|
+| `TPM_ENABLE` | `FALSE` | Master switch. Guards all TPM drivers, libraries, and PCDs. |
+| `TPM_CONFIG_ENABLE` | `FALSE` | Enables `Tcg2ConfigDxe` HII configuration UI. |
+| `TPM_REPLAY_ENABLED` | `FALSE` | Enables TPM Replay overrides (uses `TpmTestingPkg` variants of Tcg2Dxe and DxeTpm2MeasureBootLib). |
+
+## Platform Memory Layout
+
+Q35 uses the standard x86 TPM memory-mapped I/O region:
+
+| Region | Address | Size | Interface |
+|--------|---------|------|-----------|
+| TPM TIS/CRB | `0xFED40000` | 0x5000 (20 KiB) | CRB or TIS (auto-detected) |
+
+The firmware communicates directly with the TPM device via MMIO, and QEMU forwards the
+I/O to swtpm over a Unix socket.
+
+The base address comes from the SecurityPkg package declaration default
+(`PcdTpmBaseAddress = 0xFED40000`). The Q35 DSC does not override it explicitly. The
+`Tcg2ConfigPei` driver detects the TPM at this address during PEI.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ UEFI Firmware (x86_64)                                                   │
+│                                                                          │
+│  ┌─── PEI Phase ──────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  Tcg2ConfigPei                                                     │  │
+│  │    │ Detect TPM 1.2 vs 2.0 at 0xFED40000                           │  │
+│  │    │ Set PcdTpmInstanceGuid accordingly                            │  │
+│  │    ▼                                                               │  │
+│  │  Tcg2Pei                                                           │  │
+│  │    │ Tpm2Startup(TPM_SU_CLEAR)                                     │  │
+│  │    │ SyncPcrAllocationsAndPcrMask()                                │  │
+│  │    │ Tpm2SelfTest()                                                │  │
+│  │    │ Measure firmware volumes (CRTM) into PCR[0-7]                 │  │
+│  │    │ Uses Tpm2DeviceLibDTpm (direct MMIO)                          │  │
+│  │    ▼                                                               │  │
+│  │  Install TpmInitializedPpi                                         │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌─── DXE Phase ──────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  Tcg2Dxe                                                           │  │
+│  │    │ Uses Tpm2DeviceLibRouter → Tpm2InstanceLibDTpm (direct MMIO)  │  │
+│  │    │ Registers hash algorithms via HashLibBaseCryptoRouter         │  │
+│  │    ▼                                                               │  │
+│  │  Installs EFI_TCG2_PROTOCOL                                        │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌─── BDS Phase ──────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  DeviceBootManagerAfterConsole                                     │  │
+│  │    │ Tcg2PhysicalPresenceLibProcessRequest (NULL)                  │  │
+│  │    │ Process any pending PP request before shell launch            │  │
+│  │    ▼                                                               │  │
+│  │  Creates TCG2_PHYSICAL_PRESENCE_VARIABLE if it doesn't exist       │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌─── UEFI Shell ─────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  UEFI Shell / OS / TpmTestApp                                      │  │
+│  │    │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)                    │  │
+│  │    │ Tcg2Protocol->GetCapability / SetActivePcrBanks / etc.        │  │
+│  └────┼───────────────────────────────────────────────────────────────┘  │
+│       ▼                                                                  │
+│  Tpm2DeviceLibDTpm ─── direct MMIO reads/writes to 0xFED40000            │
+│       │                                                                  │
+├───────┼──────────────────────────────────────────────────────────────────┤
+│       ▼                                                                  │
+│  QEMU TPM TIS device (-device tpm-tis,tpmdev=tpm0)                       │
+│       │                                                                  │
+│       ▼                                                                  │
+│  Unix socket ──────── swtpm process (--tpm2)                             │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## TPM Device Library Stack
+
+Q35 uses two different patterns for accessing the TPM, depending on the firmware phase:
+
+### PEI Phase: Direct MMIO (`Tpm2DeviceLibDTpm`)
+
+```
+Tcg2Pei
+  │ Tpm2SubmitCommand()
+  ▼
+Tpm2DeviceLibDTpm
+  │ Auto-detects CRB vs TIS vs FIFO via InterfaceId register
+  │ DTpm2SubmitCommand() dispatches:
+  │   CRB  → PtpCrbTpmCommand()
+  │   FIFO → Tpm2TisTpmCommand()
+  │   TIS  → Tpm2TisTpmCommand()
+  ▼
+Direct MMIO to 0xFED40000
+```
+
+`Tpm2DeviceLibDTpm` reads the `InterfaceId` register at `PcdTpmBaseAddress + 0x30` to
+determine the interface type. QEMU's `tpm-tis` device presents a TIS/FIFO interface.
+
+### DXE Phase: Router Pattern (`Tpm2DeviceLibRouter`)
+
+```
+Tcg2Dxe
+  │ Tpm2SubmitCommand()
+  ▼
+Tpm2DeviceLibRouterDxe
+  │ Delegates to registered TPM2_DEVICE_INTERFACE
+  ▼
+Tpm2InstanceLibDTpm (constructor registers with router)
+  │ DTpm2SubmitCommand() — same dispatch as PEI
+  ▼
+Direct MMIO to 0xFED40000
+```
+
+The router pattern exists to support future scenarios where multiple TPM device types
+could coexist. The router accepts only the instance whose `ProviderGuid` matches
+`PcdTpmInstanceGuid`.
+
+### Other DXE Drivers: TCG2 Protocol (`Tpm2DeviceLibTcg2`)
+
+Most DXE drivers that need TPM access use `Tpm2DeviceLibTcg2`, which goes through the
+TCG2 Protocol rather than direct MMIO. Only Tcg2Dxe itself uses `Tpm2DeviceLibRouter`
+with direct MMIO.
+
+### CRB Register Layout
+
+If the TPM presents a CRB interface (as opposed to TIS/FIFO), the register layout per
+the TCG PC Client Platform TPM Profile (PTP) specification:
+
+| Offset | Register | Description |
+|--------|----------|-------------|
+| `0x00` | `LocalityState` | Current locality ownership |
+| `0x08` | `LocalityControl` | Request access, relinquish, seize |
+| `0x0C` | `LocalityStatus` | Granted / been seized status |
+| `0x30` | `InterfaceId` | CRB vs FIFO detection, version, VID/DID |
+| `0x40` | `CrbControlRequest` | `cmdReady` (BIT0), `goIdle` (BIT1) |
+| `0x44` | `CrbControlStatus` | `tpmIdle` (BIT0), `tpmSts` (BIT1) |
+| `0x48` | `CrbControlCancel` | Write 1 to cancel in-progress command |
+| `0x4C` | `CrbControlStart` | Write 1 to begin command execution |
+| `0x58` | `CrbControlCommandSize` | Command buffer size (typically `0xF80`) |
+| `0x5C` | `CrbControlCommandAddressLow` | Low 32 bits of command buffer address |
+| `0x60` | `CrbControlCommandAddressHigh` | High 32 bits of command buffer address |
+| `0x64` | `CrbControlResponseSize` | Response buffer size (typically `0xF80`) |
+| `0x68` | `CrbControlResponseAddress` | Low 64 bits of response buffer address |
+| `0x80` | `CrbDataBuffer[0xF80]` | 3968-byte shared command/response buffer |
+
+### TIS Register Layout
+
+QEMU's `tpm-tis` device presents a TIS (TPM Interface Specification) / FIFO interface.
+The key registers:
+
+| Offset | Register | Description |
+|--------|----------|-------------|
+| `0x00` | `Access` | Locality access control |
+| `0x08` | `IntEnable` | Interrupt enable |
+| `0x10` | `IntVector` | Interrupt vector |
+| `0x18` | `STS` | Status (commandReady, tpmGo, dataAvail, burstCount) |
+| `0x24` | `DataFifo` | Data I/O register (write commands, read responses) |
+| `0xF00` | `Vid` | Vendor ID |
+| `0xF04` | `Did` | Device ID |
+| `0xF08` | `Rid` | Revision ID |
+
+The TIS flow uses `BurstCount` from the STS register to pace reads and writes through
+the `DataFifo` register, one burst at a time.
+
+## Hash Library Architecture
+
+Tcg2Dxe and Tcg2Pei both use `HashLibBaseCryptoRouter` with all five hash instance
+libraries linked:
+
+```ini
+# Per-module library overrides for Tcg2Dxe and Tcg2Pei
+HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
+NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
+NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
+NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
+NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
+NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+```
+
+### Registration Flow
+
+1. `HashLibBaseCryptoRouterConstructor` resets `PcdTcg2HashAlgorithmBitmap` to 0.
+2. Each `HashInstanceLib` constructor calls `RegisterHashInterfaceLib()`.
+3. `RegisterHashInterfaceLib()` checks the algorithm against `PcdTpm2HashMask` (`0x02` =
+   SHA256 only). Algorithms not in the mask return `EFI_UNSUPPORTED`.
+
+### Hash Algorithm Bitmask Values
+
+| Algorithm | Bit | Value |
+|-----------|-----|-------|
+| SHA1 | BIT0 | `0x01` |
+| SHA256 | BIT1 | `0x02` |
+| SHA384 | BIT2 | `0x04` |
+| SHA512 | BIT3 | `0x08` |
+| SM3_256 | BIT4 | `0x10` |
+
+### Filtering Chain
+
+```
+PcdTpm2HashMask (0x02)
+        │
+        ▼
+RegisterHashInterfaceLib() ── gates which HashInstanceLibs register
+        │
+        ▼
+PcdTcg2HashAlgorithmBitmap ── result of all successful registrations
+        │
+        ▼
+Tcg2Dxe intersects with TPM-reported capabilities
+        │
+        ▼
+Final ActivePcrBanks / HashAlgorithmBitmap in EFI_TCG2_BOOT_SERVICE_CAPABILITY
+```
+
+## Physical Presence Interface
+
+### Library Selection
+
+| `TPM_ENABLE` | Library | Behavior |
+|--------------|---------|----------|
+| `FALSE` | `Tcg2PhysicalPresenceLibNull` | All functions stubbed |
+| `TRUE` | `DxeTcg2PhysicalPresenceMinimumLib` | Auto-confirms Clear; rejects all other operations |
+
+The MinimumLib implementation:
+
+- **Auto-confirms** TPM Clear operations without user prompting.
+- **Rejects** SET_PCR_BANKS, LOG_ALL_DIGESTS, and other operations with
+  `TCG_PP_RETURN_TPM_OPERATION_RESPONSE_FAILURE`.
+- Does **not** create or use `TCG2_PHYSICAL_PRESENCE_FLAGS_VARIABLE`.
+
+### ProcessRequest in BDS
+
+`DeviceBootManagerAfterConsole()` in `DeviceBootManagerLibQemu` handles PP processing
+before the shell launches:
+
+```c
+if (BootMode != BOOT_ON_FLASH_UPDATE) {
+    // 1. GUI-based PP prompt (if TPM_PP_PROTOCOL is available)
+    Status = gBS->LocateProtocol (&gTpmPpProtocolGuid, NULL, (VOID **)&TpmPp);
+    if (!EFI_ERROR (Status) && (TpmPp != NULL)) {
+        TpmPp->PromptForConfirmation (TpmPp);
+    }
+
+    // 2. Standard TCG2 PP processing
+    Tcg2PhysicalPresenceLibProcessRequest (NULL);
+}
+```
+
+`ProcessRequest` reads the `Tcg2PhysicalPresence` NV variable (creating it with zeroed
+contents if it doesn't exist), executes any pending request, and stores the result for
+later retrieval via `ReturnOperationResponseToOsFunction()`.
+
+## swtpm Setup
+
+### Installation
+
+swtpm requires Unix sockets, so it must run in a Linux environment. On Windows,
+use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (Windows
+Subsystem for Linux).
+
+```bash
+# Windows (from a WSL terminal)
+wsl --install          # if WSL is not yet enabled
+wsl                    # enter the WSL environment
+
+# Ubuntu/Debian (native or WSL)
+sudo apt install swtpm swtpm-tools
+
+# Fedora
+sudo dnf install swtpm swtpm-tools
+```
+
+### Manual Setup
+
+Create the TPM state directory and start swtpm:
+
+```bash
+mkdir -p /tmp/mytpm1
+swtpm socket \
+  --tpmstate dir=/tmp/mytpm1 \
+  --ctrl type=unixio,path=/tmp/mytpm1/swtpm-sock \
+  --tpm2 \
+  --log level=20
+```
+
+### Automatic Setup (QemuRunner)
+
+When the `TPM_DEV` environment variable is set, `QemuRunner.py` automatically starts
+swtpm in a background thread before launching QEMU:
+
+```python
+@staticmethod
+def RunThread(env):
+    tpm_path = env.GetValue("TPM_DEV")
+    tpm_cmd = "swtpm"
+    tpm_args = (
+        f"socket --tpmstate dir={'/'.join(tpm_path.rsplit('/', 1)[:-1])} "
+        f"--ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
+    )
+    utility_functions.RunCmd(tpm_cmd, tpm_args)
+```
+
+The thread is launched before QEMU starts and joined after QEMU exits.
+
+### QEMU Arguments
+
+The `QemuCommandBuilder.with_tpm()` method adds three arguments for Q35:
+
+```
+-chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
+-tpmdev emulator,id=tpm0,chardev=chrtpm
+-device tpm-tis,tpmdev=tpm0
+```
+
+The `-device tpm-tis` argument is Q35-specific — it attaches a TIS-compatible TPM device
+to the Q35 chipset at the standard address `0xFED40000`.
+
+## Communication Flow
+
+Complete path from a shell application to swtpm:
+
+```
+TpmTestApp (UEFI Shell)
+  │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)
+  │ Tcg2Protocol->SetActivePcrBanks(0x02)
+  ▼
+Tcg2Dxe (EFI_TCG2_PROTOCOL)
+  │ Validates bank mask against HashAlgorithmBitmap
+  │ Calls Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction()
+  │   ↳ MinimumLib: rejects SET_PCR_BANKS → returns EFI_UNSUPPORTED
+  │   ↳ MinimumLib: NO_ACTION (already-active) → writes NV variable → EFI_SUCCESS
+  ▼
+Tpm2CommandLib (for direct TPM commands like GetCapability)
+  │ Serializes TPM2 command structure into byte buffer
+  │ Calls Tpm2SubmitCommand(cmdBuffer, cmdSize, rspBuffer, &rspSize)
+  ▼
+Tpm2DeviceLibRouter → Tpm2InstanceLibDTpm
+  │ DTpm2SubmitCommand() — detects interface type (TIS on QEMU)
+  ▼
+Tpm2TisTpmCommand (Tpm2Tis.c)
+  │ 1. TisPcPrepareCommand: set TIS_PC_STS_COMMAND_READY
+  │ 2. Write command bytes to DataFifo (paced by BurstCount)
+  │ 3. Set TIS_PC_STS_GO to start execution
+  │ 4. Poll STS for DataAvail (90 second timeout)
+  │ 5. Read response header from DataFifo
+  │ 6. Read remaining response bytes (paced by BurstCount)
+  │ 7. Set TIS_PC_STS_READY (return to idle)
+  ▼
+MMIO to 0xFED40000 (QEMU TIS device)
+  │
+  ▼
+QEMU tpm-tis device ──── Unix socket ──── swtpm process
+```
+
+## PCDs Reference
+
+### Required PCDs (set when TPM_ENABLE=TRUE)
+
+| PCD | Value | Type | Purpose |
+|-----|-------|------|---------|
+| `PcdTpmBaseAddress` | `0xFED40000` (package default) | DynamicDefault | TPM TIS/CRB MMIO base address |
+| `PcdTpm2HashMask` | `0x02` | DynamicDefault | Hash algorithm filter (SHA256 only) |
+| `PcdTpmInstanceGuid` | `gEfiTpmDeviceInstanceTpm20DtpmGuid` | DynamicDefault | Selects discrete TPM 2.0 device type (set by Tcg2ConfigPei at runtime) |
+| `PcdTpm2AcpiTableRev` | `4` | DynamicHii | ACPI TPM2 table revision |
+| `PcdUserPhysicalPresence` | `FALSE` | FixedAtBuild | No physical user presence assertion |
+
+### Memory Type PCDs
+
+| PCD | Value (pages) | Purpose |
+|-----|---------------|---------|
+| `PcdMemoryTypeEfiACPIReclaimMemory` | `0x2B` (43) | Includes TPM ACPI tables |
+| `PcdMemoryTypeEfiACPIMemoryNVS` | `0x80` (128) | ACPI NVS memory |
+| `PcdMemoryTypeEfiReservedMemoryType` | `0x510` | Reserved memory |
+| `PcdMemoryTypeEfiRuntimeServicesCode` | `0x100` | Runtime code |
+| `PcdMemoryTypeEfiRuntimeServicesData` | `0x700` | Runtime data |
+
+### Conditional PCDs (TPM_CONFIG_ENABLE=TRUE)
+
+| PCD | Value | Purpose |
+|-----|-------|---------|
+| `PcdTcgPhysicalPresenceInterfaceVer` | `"1.3"` | TCG PPI specification version reported to OS |

--- a/docs/TPM/TpmQemuQ35.md
+++ b/docs/TPM/TpmQemuQ35.md
@@ -29,7 +29,7 @@ stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
 The following defines control TPM behavior in `QemuQ35Pkg.dsc`:
 
 | Define | Default | Purpose |
-|--------|---------|---------|
+| -------- | --------- | --------- |
 | `TPM_ENABLE` | `FALSE` | Master switch. Guards all TPM drivers, libraries, and PCDs. |
 | `TPM_CONFIG_ENABLE` | `FALSE` | Enables `Tcg2ConfigDxe` HII configuration UI. |
 | `TPM_REPLAY_ENABLED` | `FALSE` | Enables TPM Replay overrides (uses `TpmTestingPkg` variants of Tcg2Dxe and DxeTpm2MeasureBootLib). |
@@ -39,7 +39,7 @@ The following defines control TPM behavior in `QemuQ35Pkg.dsc`:
 Q35 uses the standard x86 TPM memory-mapped I/O region:
 
 | Region | Address | Size | Interface |
-|--------|---------|------|-----------|
+| -------- | --------- | ------ | ----------- |
 | TPM TIS/CRB | `0xFED40000` | 0x5000 (20 KiB) | CRB or TIS (auto-detected) |
 
 The firmware communicates directly with the TPM device via MMIO, and QEMU forwards the
@@ -51,7 +51,7 @@ The base address comes from the SecurityPkg package declaration default
 
 ## Architecture Overview
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────────────┐
 │ UEFI Firmware (x86_64)                                                   │
 │                                                                          │
@@ -113,7 +113,7 @@ Q35 uses two different patterns for accessing the TPM, depending on the firmware
 
 ### PEI Phase: Direct MMIO (`Tpm2DeviceLibDTpm`)
 
-```
+```text
 Tcg2Pei
   │ Tpm2SubmitCommand()
   ▼
@@ -132,7 +132,7 @@ determine the interface type. QEMU's `tpm-tis` device presents a TIS/FIFO interf
 
 ### DXE Phase: Router Pattern (`Tpm2DeviceLibRouter`)
 
-```
+```text
 Tcg2Dxe
   │ Tpm2SubmitCommand()
   ▼
@@ -161,7 +161,7 @@ If the TPM presents a CRB interface (as opposed to TIS/FIFO), the register layou
 the TCG PC Client Platform TPM Profile (PTP) specification:
 
 | Offset | Register | Description |
-|--------|----------|-------------|
+| -------- | ---------- | ------------- |
 | `0x00` | `LocalityState` | Current locality ownership |
 | `0x08` | `LocalityControl` | Request access, relinquish, seize |
 | `0x0C` | `LocalityStatus` | Granted / been seized status |
@@ -183,7 +183,7 @@ QEMU's `tpm-tis` device presents a TIS (TPM Interface Specification) / FIFO inte
 The key registers:
 
 | Offset | Register | Description |
-|--------|----------|-------------|
+| -------- | ---------- | ------------- |
 | `0x00` | `Access` | Locality access control |
 | `0x08` | `IntEnable` | Interrupt enable |
 | `0x10` | `IntVector` | Interrupt vector |
@@ -221,7 +221,7 @@ NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
 ### Hash Algorithm Bitmask Values
 
 | Algorithm | Bit | Value |
-|-----------|-----|-------|
+| ----------- | ----- | ------- |
 | SHA1 | BIT0 | `0x01` |
 | SHA256 | BIT1 | `0x02` |
 | SHA384 | BIT2 | `0x04` |
@@ -230,7 +230,7 @@ NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
 
 ### Filtering Chain
 
-```
+```text
 PcdTpm2HashMask (0x02)
         │
         ▼
@@ -251,7 +251,7 @@ Final ActivePcrBanks / HashAlgorithmBitmap in EFI_TCG2_BOOT_SERVICE_CAPABILITY
 ### Library Selection
 
 | `TPM_ENABLE` | Library | Behavior |
-|--------------|---------|----------|
+| -------------- | --------- | ---------- |
 | `FALSE` | `Tcg2PhysicalPresenceLibNull` | All functions stubbed |
 | `TRUE` | `DxeTcg2PhysicalPresenceMinimumLib` | Auto-confirms Clear; rejects all other operations |
 
@@ -340,7 +340,7 @@ The thread is launched before QEMU starts and joined after QEMU exits.
 
 The `QemuCommandBuilder.with_tpm()` method adds three arguments for Q35:
 
-```
+```text
 -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
 -tpmdev emulator,id=tpm0,chardev=chrtpm
 -device tpm-tis,tpmdev=tpm0
@@ -353,7 +353,7 @@ to the Q35 chipset at the standard address `0xFED40000`.
 
 Complete path from a shell application to swtpm:
 
-```
+```text
 TpmTestApp (UEFI Shell)
   │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)
   │ Tcg2Protocol->SetActivePcrBanks(0x02)
@@ -391,7 +391,7 @@ QEMU tpm-tis device ──── Unix socket ──── swtpm process
 ### Required PCDs (set when TPM_ENABLE=TRUE)
 
 | PCD | Value | Type | Purpose |
-|-----|-------|------|---------|
+| ----- | ------- | ------ | --------- |
 | `PcdTpmBaseAddress` | `0xFED40000` (package default) | DynamicDefault | TPM TIS/CRB MMIO base address |
 | `PcdTpm2HashMask` | `0x02` | DynamicDefault | Hash algorithm filter (SHA256 only) |
 | `PcdTpmInstanceGuid` | `gEfiTpmDeviceInstanceTpm20DtpmGuid` | DynamicDefault | Selects discrete TPM 2.0 device type (set by Tcg2ConfigPei at runtime) |
@@ -401,7 +401,7 @@ QEMU tpm-tis device ──── Unix socket ──── swtpm process
 ### Memory Type PCDs
 
 | PCD | Value (pages) | Purpose |
-|-----|---------------|---------|
+| ----- | --------------- | --------- |
 | `PcdMemoryTypeEfiACPIReclaimMemory` | `0x2B` (43) | Includes TPM ACPI tables |
 | `PcdMemoryTypeEfiACPIMemoryNVS` | `0x80` (128) | ACPI NVS memory |
 | `PcdMemoryTypeEfiReservedMemoryType` | `0x510` | Reserved memory |
@@ -411,5 +411,5 @@ QEMU tpm-tis device ──── Unix socket ──── swtpm process
 ### Conditional PCDs (TPM_CONFIG_ENABLE=TRUE)
 
 | PCD | Value | Purpose |
-|-----|-------|---------|
+| ----- | ------- | --------- |
 | `PcdTcgPhysicalPresenceInterfaceVer` | `"1.3"` | TCG PPI specification version reported to OS |

--- a/docs/TPM/TpmQemuSbsa.md
+++ b/docs/TPM/TpmQemuSbsa.md
@@ -1,0 +1,668 @@
+# TPM on QEMU SBSA
+
+This document describes the TPM 2.0 architecture for the QEMU SBSA platform. SBSA uses
+a dual-CRB design with an FF-A (Firmware Framework for Arm A-Profile) mediated communication
+path between the normal world and the secure world.
+
+Please note that TPM for SBSA is not supported by default and modifications to your QEMU are
+required to get TPM support. These changes are planned to be upstreamed in the future.
+
+For more details please message either Kun Qin <Kun.Qin@microsoft.com> or Raymond Diaz
+<raymond.diaz@microsoft.com> for more information.
+
+## Table of Contents
+
+- [Build Configuration](#build-configuration)
+- [Platform Memory Layout](#platform-memory-layout)
+- [Architecture Overview](#architecture-overview)
+- [Secure Partitions](#secure-partitions)
+- [CRB Regions](#crb-regions)
+- [FF-A Communication Protocol](#ff-a-communication-protocol)
+- [Hash Library Architecture](#hash-library-architecture)
+- [Physical Presence Interface](#physical-presence-interface)
+- [ACPI Integration](#acpi-integration)
+- [swtpm Setup](#swtpm-setup)
+- [Communication Flow](#communication-flow)
+- [PCDs Reference](#pcds-reference)
+
+## Build Configuration
+
+The TPM is disabled by default. To enable it, pass the build define and provide the swtpm
+socket path or provide it in a BuildConfig.conf file placed at the root level of the repo:
+
+```bash
+stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
+  BLD_*_TPM2_ENABLE=TRUE \
+  TPM_DEV=/tmp/mytpm1/swtpm-sock
+```
+
+The following defines control TPM behavior in `QemuSbsaPkg.dsc`:
+
+| Define | Default | Purpose |
+|--------|---------|---------|
+| `TPM2_ENABLE` | `FALSE` | Master switch. Guards all TPM drivers, libraries, and PCDs. |
+| `TPM2_CONFIG_ENABLE` | `FALSE` | Enables `Tcg2ConfigDxe` HII configuration UI. |
+
+When `TPM2_ENABLE=TRUE`, the build additionally passes `-DTPM2_ENABLE` to the C compiler
+via build options, allowing C code to use `#ifdef TPM2_ENABLE` guards.
+
+## Platform Memory Layout
+
+The SBSA platform defines two distinct TPM memory regions:
+
+| Region | Address | Size | Visibility |
+|--------|---------|------|------------|
+| Internal CRB | `0x100_00200000` | 0x10 pages | Normal world + Secure world |
+| External CRB | `0x000_60120000` | 0x10 pages | Secure world only |
+
+The Internal CRB address is published via PCDs:
+
+- `PcdTpmBaseAddress` = `0x10000200000`
+- `PcdTpmMaxAddress` = `0x10000204FFF` (5 localities × 0x1000)
+
+The Internal CRB is marked as `EfiACPIMemoryNVS` via a HOB in `SbsaQemuMem.c` so the OS
+can locate it through the ACPI TPM2 table.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ UEFI Firmware (AARCH64)                                                  │
+│                                                                          │
+│  ┌─── SEC Phase ──────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  Tpm2StartupLib                                                    │  │
+│  │    │ Tpm2RequestUseTpm() — request locality access via FF-A        │  │
+│  │    │ Tpm2Startup(TPM_SU_CLEAR) — initialize TPM, clear PCR banks   │  │
+│  │    │ Uses Tpm2DeviceSecLibFfa + ArmFfaSecLib                       │  │
+│  │    ▼                                                               │  │
+│  │  TPM ready for DXE phase                                           │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌─── DXE Phase ──────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  Tcg2Dxe                                                           │  │
+│  │    │ Uses Tpm2DeviceLibRouter → Tpm2InstanceLibFfa (FF-A to MSSP)  │  │
+│  │    │ Registers hash algorithms via HashLibBaseCryptoRouter         │  │
+│  │    ▼                                                               │  │
+│  │  Installs EFI_TCG2_PROTOCOL                                        │  │
+│  │                                                                    │  │
+│  │  Tcg2AcpiFfa                                                       │  │
+│  │    │ Publishes TPM2 ACPI table and SSDT with TPM0 device node      │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌─── BDS Phase ──────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  DeviceBootManagerAfterConsole                                     │  │
+│  │    │ Tcg2PhysicalPresenceLibProcessRequest (NULL)                  │  │
+│  │    │ Process any pending PP request before shell launch            │  │
+│  │    ▼                                                               │  │
+│  │  Creates TCG2_PHYSICAL_PRESENCE_VARIABLE if it doesn't exist       │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+│                                                                          │
+│  ┌─── UEFI Shell ─────────────────────────────────────────────────────┐  │
+│  │                                                                    │  │
+│  │  UEFI Shell / OS / TpmTestApp                                      │  │
+│  │    │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)                    │  │
+│  │    │ Tcg2Protocol->GetCapability / SetActivePcrBanks / etc.        │  │
+│  └────┼───────────────────────────────────────────────────────────────┘  │
+│       ▼                                                                  │
+│  Tpm2DeviceLibFfa ─── Writes to Internal CRB @ 0x100_00200000            │
+│       │               then sends FF-A DirectReq2 to the TpmService       │
+│       │                                                                  │
+├───────┼──────────────────────────────────────────────────────────────────┤
+│ EL3 (SPMC / TF-A)  ─── routes FF-A message to partition 0x8002           │
+├───────┼──────────────────────────────────────────────────────────────────┤
+│       ▼                                                                  │
+│ SECURE WORLD (SEL1)                                                      │
+│                                                                          │
+│  MSSP (MsSecurePartition, id=0x8002)                                     │
+│       │                                                                  │
+│       ▼                                                                  │
+│  TpmServiceLib ─── State machine (IDLE → READY → COMPLETE → IDLE)        │
+│       │                                                                  │
+│       ▼                                                                  │
+│  TpmServiceStateTranslationLib ─── Translates CRB style communications   │
+│       │                            to the style supported by the TPM     │
+│       │                            i.e. FIFO for QEMU SBSA               │
+│       │  Library Responsibilities:                                       │
+│       │  1. Copy command from Internal CRB → local buffer                │
+│       │  2. Write command to External CRB @ 0x60120000                   │
+│       │  3. Trigger execution on external TPM through the CRB MMIO       │
+│       │  4. Read response from External CRB                              │
+│       │  5. Copy response back to Internal CRB                           │
+│       │                                                                  │
+├───────┼──────────────────────────────────────────────────────────────────┤
+│       ▼                                                                  │
+│  QEMU TPM device (MMIO @ 0x60120000)                                     │
+│       │                                                                  │
+│       ▼                                                                  │
+│  Unix socket ──────── swtpm process (--tpm2)                             │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Secure Partitions
+
+Two FF-A Secure Partitions are involved in TPM operations.
+
+### MSSP — Microsoft Secure Services Partition (id=0x8002)
+
+Configured in `Platforms/QemuSbsaPkg/fdts/qemu_sbsa_mssp_rust_config.dts`:
+
+| Property | Value |
+|----------|-------|
+| Partition ID | `0x8002` |
+| Exception Level | SEL1 |
+| Execution State | AARCH64 |
+| Load Address | `0x20800000` |
+| Image Size | 4 MiB |
+| Boot Order | 2 |
+
+The MSSP hosts the TPM service and is granted access to both CRB regions:
+
+```dts
+device-regions {
+    internal_tpm_crb {
+        base-address = <0x100 0x00200000>;
+        pages-count = <0x10>;
+        attributes = <SECURE_RW>;
+    };
+    external_tpm_crb {
+        base-address = <0x000 0x60120000>;
+        pages-count = <0x10>;
+        attributes = <SECURE_RW>;
+    };
+};
+```
+
+The MSSP publishes three service UUIDs. The TPM service UUID is:
+
+```
+17b862a4-1806-4faf-86b3-089a58353861
+```
+
+Key libraries running inside the MSSP:
+
+- **TpmServiceLib** — handles incoming FF-A messages, implements the CRB state machine
+  (IDLE → cmdReady → READY → start → COMPLETE → goIdle → IDLE). Note that this service is
+  based on the CRB over FF-A specification released by ARM. See:
+  [TPM Service Command Response Buffer Interface Over FF-A](https://developer.arm.com/documentation/den0138/latest/)
+- **TpmServiceStateTranslationLib** — translates between the Internal CRB (CRB interface)
+  and the External CRB (which may be CRB or FIFO depending on QEMU configuration). On
+  QEMU SBSA the external interface is FIFO.
+
+### StMM — Standalone MM Partition (id=0x8001)
+
+Configured in `Platforms/QemuSbsaPkg/fdts/qemu_sbsa_stmm_config.dts`:
+
+| Property | Value |
+|----------|-------|
+| Partition ID | `0x8001` |
+| Exception Level | SEL0 |
+| Execution State | AARCH64 |
+| Load Address | `0x20002000` |
+| Image Size | 3 MiB |
+| Boot Order | 0 |
+
+The StMM partition hosts secure variable storage (FTW, VariableRuntimeDxe), and the
+`Tcg2StandaloneMmArm` driver which processes Physical Presence Interface commands from
+the normal world for NV variable access.
+
+## CRB Regions
+
+### CRB Register Layout (PTP CRB Interface)
+
+Each locality occupies 0x1000 bytes. The register layout per the TCG PC Client Platform
+TPM Profile (PTP) specification, defined in `TpmPtp.h`:
+
+| Offset | Register | Description |
+|--------|----------|-------------|
+| `0x00` | `LocalityState` | Current locality ownership |
+| `0x08` | `LocalityControl` | Request access, relinquish, seize |
+| `0x0C` | `LocalityStatus` | Granted / been seized status |
+| `0x30` | `InterfaceId` | CRB vs FIFO detection, version, VID/DID |
+| `0x40` | `CrbControlRequest` | `cmdReady` (BIT0), `goIdle` (BIT1) |
+| `0x44` | `CrbControlStatus` | `tpmIdle` (BIT0), `tpmSts` (BIT1) |
+| `0x48` | `CrbControlCancel` | Write 1 to cancel in-progress command |
+| `0x4C` | `CrbControlStart` | Write 1 to begin command execution |
+| `0x58` | `CrbControlCommandSize` | Command buffer size (typically `0xF80`) |
+| `0x5C` | `CrbControlCommandAddressLow` | Low 32 bits of command buffer address |
+| `0x60` | `CrbControlCommandAddressHigh` | High 32 bits of command buffer address |
+| `0x64` | `CrbControlResponseSize` | Response buffer size (typically `0xF80`) |
+| `0x68` | `CrbControlResponseAddress` | Low 64 bits of response buffer address |
+| `0x80` | `CrbDataBuffer[0xF80]` | 3968-byte shared command/response buffer |
+
+### Internal CRB (`0x100_00200000`)
+
+This is the CRB visible to normal-world firmware (DXE drivers and UEFI applications).
+`Tpm2DeviceLibFfa` writes TPM commands into this CRB's data buffer and reads responses
+from it. The Internal CRB uses the standard CRB register interface. It is the TPM service's
+responsibility to setup and maintain this region. The goal is to have this region mimic
+a normal MMIO CRB region only with the added caveat that an FF-A message must be sent for
+any action to be taken on any register modifications.
+
+The normal-world code performs MMIO writes to the CRB control registers (cmdReady, Start,
+goIdle) and then sends FF-A messages to notify the secure partition. The secure partition
+reads the command data from the Internal CRB, proxies it to the External CRB, and writes
+the response back.
+
+### External CRB (`0x60120000`)
+
+This is the QEMU-emulated TPM device MMIO region. It is **only accessible from the secure
+world** i.e. the TPM Service within the MSSP secure partition. On QEMU SBSA, this region
+presents a FIFO interface (**not CRB**), which the `TpmServiceStateTranslationLib` handles by
+detecting the interface type at initialization and using the appropriate FIFO
+command/response protocol (burst-count reads, data register writes).
+
+The external CRB connects to the `swtpm` process through QEMU's chardev/tpmdev
+infrastructure:
+
+```
+QEMU args: -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
+           -tpmdev emulator,id=tpm0,chardev=chrtpm
+```
+
+> **Note**: Unlike Q35, SBSA does **not** add a `-device tpm-tis-device,tpmdev=tpm0`
+> argument. As mentioned, QEMU does not support TPM for SBSA directly. Local changes
+> are required to get TPM support for SBSA. See QemuCommandBuilder.py and QemuRunner.py
+> for details on the swtpm commands.
+
+## FF-A Communication Protocol
+
+All TPM commands from normal world to secure world use FF-A Direct Request/Response
+messaging (FFA_MSG_SEND_DIRECT_REQ2 / FFA_MSG_SEND_DIRECT_RESP2) to/from the TPM Service.
+
+### Service Discovery
+
+On first use, `Tpm2DeviceLibFfa` discovers the TPM service partition:
+
+```c
+ArmFfaLibGetPartitionInfo(&gTpm2ServiceFfaGuid, &TpmPartInfo);
+```
+
+This queries the SPMC (EL3) for the partition hosting UUID `17b862a4-1806-4faf-86b3-089a58353861`,
+which returns partition ID `0x8002`. This information can be found in the manifest of the secure
+partition.
+
+### Function IDs
+
+| ID | Name | Direction | Supported |
+|----|------|-----------|-----------|
+| `0x0f000001` | `TPM2_FFA_GET_INTERFACE_VERSION` | NW → SW | YES |
+| `0x0f000101` | `TPM2_FFA_GET_FEATURE_INFO` | NW → SW | NO |
+| `0x0f000201` | `TPM2_FFA_START` | NW → SW | YES |
+| `0x0f000301` | `TPM2_FFA_REGISTER_FOR_NOTIFICATION` | NW → SW | NO |
+| `0x0f000401` | `TPM2_FFA_UNREGISTER_FROM_NOTIFICATION` | NW → SW | NO |
+| `0x0f000501` | `TPM2_FFA_FINISH_NOTIFIED` | NW → SW | NO |
+| `0x1f000001` | `TPM2_FFA_MANAGE_LOCALITY` | TF-A → SW only | YES |
+
+The `TPM2_FFA_START` function carries a qualifier in Arg1:
+
+| Qualifier | Value | Purpose |
+|-----------|-------|---------|
+| `TPM2_FFA_START_FUNC_QUALIFIER_COMMAND` | `0x0` | Execute a CRB state transition (cmdReady, start, or goIdle) |
+| `TPM2_FFA_START_FUNC_QUALIFIER_LOCALITY` | `0x1` | Request or relinquish locality access |
+
+The `TPM2_FFA_MANAGE_LOCALITY` function carries a qualifier in Arg1:
+
+| Qualifier | Value | Purpose |
+|-----------|-------|---------|
+| `TPM2_FFA_MANAGE_LOCALITY_OPEN` | `0x0` | Allows access to a locality |
+| `TPM2_FFA_MANAGE_LOCALITY_CLOSE` | `0x1` | Prevents access to a locality |
+
+Note that for both `TPM2_FFA_START` and `TPM2_FFA_MANAGE_LOCALITY` Arg2 specifies
+the locality to take action upon.
+
+### FF-A Message Sequence (Per TPM Command)
+
+A locality **must** first be requested before any commands can be sent to
+the TPM via that locality's CRB region. The active locality **must** be
+relinquished before another locality is requested. The current entity
+engaging with the TPM must take the responsibility of relinquishing the
+active locality when they are no longer using it. If the locality being
+requested is 'CLOSED', a DENIED error is returned. If the locality being
+relinquished is not the current active locality, a DENIED error is returned.
+
+A single TPM command requires multiple FF-A round trips:
+
+```
+Normal World                              Secure World (MSSP)
+────────────                              ───────────────────
+
+1. Write LocalityControl = request access
+   FFA DirectReq2(START, LOCALITY) ──────► LocalityX becomes active
+                                   ◄────── FFA DirectResp2(SUCCESS)
+
+2. Write CrbControlRequest = cmdReady
+   FFA DirectReq2(START, COMMAND) ──────► State: IDLE → READY
+                                          (prepare external TPM)
+                                  ◄────── FFA DirectResp2(SUCCESS)
+
+3. Write command to CrbDataBuffer
+   Write CrbControlStart = 1
+   FFA DirectReq2(START, COMMAND) ──────► State: READY → COMPLETE
+                                          • Copy cmd from Internal CRB
+                                          • Write cmd to External CRB
+                                          • Trigger external TPM
+                                          • Read response from External CRB
+                                          • Copy response to Internal CRB
+                                  ◄────── FFA DirectResp2(SUCCESS)
+
+4. Read response from CrbDataBuffer
+   Write CrbControlRequest = goIdle
+   FFA DirectReq2(START, COMMAND) ──────► State: COMPLETE → IDLE
+                                          (idle external TPM)
+                                  ◄────── FFA DirectResp2(SUCCESS)
+
+**OPTIONAL**
+5. Write LocalityControl = relinquish access
+   FFA DirectReq2(START, LOCALITY) ──────► LocalityX is relinquished
+                                   ◄────── FFA DirectResp2(SUCCESS)
+```
+
+If the secure partition is preempted by a non-secure interrupt during processing, the FF-A
+call returns `EFI_INTERRUPT_PENDING`. The normal-world code handles this by calling
+`ArmFfaLibRun()` in a loop until the operation completes. Note that this can only happen
+if ns-interrupts-action in the secure partition's manifest is set to 0x02, otherwise, the
+non-secure interrupt is queued and the service will continue execution until it completes
+or responds with a YIELD.
+
+## Hash Library Architecture
+
+Tcg2Dxe uses a pluggable hash library architecture based on `HashLibBaseCryptoRouter` and
+`HashInstanceLib` modules.
+
+### Registration Flow
+
+1. **Build time**: The DSC links hash instance libraries as NULL library classes into
+   Tcg2Dxe. Each instance has a constructor.
+
+   ```ini
+   # QemuSbsaPkg.dsc — Tcg2Dxe component overrides
+   SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.inf {
+     <LibraryClasses>
+       HashLib|SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.inf
+       NULL|SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.inf
+       NULL|SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.inf
+       NULL|SecurityPkg/Library/HashInstanceLibSha384/HashInstanceLibSha384.inf
+       NULL|SecurityPkg/Library/HashInstanceLibSha512/HashInstanceLibSha512.inf
+       NULL|SecurityPkg/Library/HashInstanceLibSm3/HashInstanceLibSm3.inf
+   }
+   ```
+
+2. **Module load time**: The `HashLibBaseCryptoRouterDxeConstructor` runs first and resets
+   `PcdTcg2HashAlgorithmBitmap` to 0 for the current module.
+
+3. **Instance constructors**: Each `HashInstanceLib` constructor calls
+   `RegisterHashInterfaceLib()`, which checks the algorithm against `PcdTpm2HashMask`:
+
+   ```c
+   // In RegisterHashInterfaceLib():
+   HashMask = Tpm2GetHashMaskFromAlgo(&HashInterface->HashGuid);
+   Tpm2HashMask = PcdGet32(PcdTpm2HashMask);
+
+   // If PcdTpm2HashMask is non-zero and this algo's bit isn't set, REJECT
+   if ((Tpm2HashMask != 0) && ((HashMask & Tpm2HashMask) == 0)) {
+     return EFI_UNSUPPORTED;
+   }
+   ```
+
+4. **Tcg2Dxe DriverEntry**: Queries the TPM for supported/active PCR banks via
+   `Tpm2GetCapabilitySupportedAndActivePcrs()`, then intersects with the registered hash
+   bitmap:
+
+   ```c
+   mTcgDxeData.BsCap.HashAlgorithmBitmap = TpmHashAlgorithmBitmap
+                                          & PcdGet32(PcdTcg2HashAlgorithmBitmap);
+   mTcgDxeData.BsCap.ActivePcrBanks      = ActivePCRBanks
+                                          & PcdGet32(PcdTcg2HashAlgorithmBitmap);
+   ```
+
+### Hash Algorithm Bitmask Values
+
+| Algorithm | Bit | Value |
+|-----------|-----|-------|
+| SHA1 | BIT0 | `0x01` |
+| SHA256 | BIT1 | `0x02` |
+| SHA384 | BIT2 | `0x04` |
+| SHA512 | BIT3 | `0x08` |
+| SM3_256 | BIT4 | `0x10` |
+
+### Filtering Chain
+
+```
+PcdTpm2HashMask (0x02)
+        │
+        ▼
+RegisterHashInterfaceLib() ── gates which HashInstanceLibs register
+        │
+        ▼
+PcdTcg2HashAlgorithmBitmap ── result of all successful registrations
+        │
+        ▼
+Tcg2Dxe intersects with TPM-reported capabilities
+        │
+        ▼
+Final ActivePcrBanks / HashAlgorithmBitmap in EFI_TCG2_BOOT_SERVICE_CAPABILITY
+```
+
+## Physical Presence Interface
+
+### Library Selection
+
+When `TPM2_ENABLE=TRUE`, SBSA uses `DxeTcg2PhysicalPresenceMinimumLib`. This is a
+simplified implementation that:
+
+- **Auto-confirms** TPM Clear operations without user prompting.
+- **Rejects** all other operations (SET_PCR_BANKS, LOG_ALL_DIGESTS, etc.) with
+  `TCG_PP_RETURN_TPM_OPERATION_RESPONSE_FAILURE`.
+
+When `TPM2_ENABLE=FALSE`, the null implementation at
+`QemuPkg/Library/Tcg2PhysicalPresenceLibNull/` is used, which stubs all functions.
+
+### ProcessRequest in BDS
+
+`Tcg2PhysicalPresenceLibProcessRequest()` is called from
+`DeviceBootManagerAfterConsole()` in `DeviceBootManagerLibQemu`. This runs during BDS
+before the shell launches. It:
+
+1. Reads the `Tcg2PhysicalPresence` NV variable (creates it if missing).
+2. Executes any pending PP request stored in the variable.
+3. Stores the result back for `ReturnOperationResponseToOsFunction()` to report.
+
+### Tcg2StandaloneMmArm (Secure World)
+
+The `Tcg2StandaloneMmArm` driver runs in the StMM partition (id=0x8001). It handles
+Physical Presence NV variable operations when called from the DXE-phase PP library via
+MM communicate. This is necessary because NV variable writes go through the secure
+variable store in StMM.
+
+## ACPI Integration
+
+### TPM2 ACPI Table
+
+Published by `Tcg2AcpiFfa.c`:
+
+| Field | Value |
+|-------|-------|
+| Start Method | CRB with FF-A (`0x0C`) |
+| Control Area Address | `PcdTpmBaseAddress + 0x40` |
+| Command Buffer | `PcdTpmBaseAddress + 0x80`, size `0xF80` |
+| Response Buffer | `PcdTpmBaseAddress + 0x80`, size `0xF80` |
+| Platform Parameters | Partition ID from `PcdTpmServiceFfaPartitionId` |
+
+### TPM ACPI Device (SSDT)
+
+An SSDT is published with a `TPM0` device node containing:
+
+- `_HID` patched with the TPM manufacturer ID read from hardware.
+- `_CRS` with a QWordMemory resource pointing to `PcdTpmBaseAddress` through
+  `PcdTpmMaxAddress`.
+- `_DSM` implementing TCG PPI operations 1–8 for OS-initiated Physical Presence requests.
+- An `FFixedHw` OperationRegion for FF-A DirectReq2 passthrough from the OS.
+
+## swtpm Setup
+
+### Installation
+
+swtpm requires Unix sockets, so it must run in a Linux environment. On Windows,
+use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (Windows
+Subsystem for Linux).
+
+```bash
+# Windows (from a WSL terminal)
+wsl --install          # if WSL is not yet enabled
+wsl                    # enter the WSL environment
+
+# Ubuntu/Debian (native or WSL)
+sudo apt install swtpm swtpm-tools
+
+# Fedora
+sudo dnf install swtpm swtpm-tools
+```
+
+### Manual Setup
+
+Create the TPM state directory and start swtpm before launching QEMU:
+
+```bash
+mkdir -p /tmp/mytpm1
+swtpm socket \
+  --tpmstate dir=/tmp/mytpm1 \
+  --ctrl type=unixio,path=/tmp/mytpm1/swtpm-sock \
+  --tpm2 \
+  --log level=20
+```
+
+### Automatic Setup (QemuRunner)
+
+When the `TPM_DEV` environment variable is set, `QemuRunner.py` automatically starts
+swtpm in a background thread before launching QEMU:
+
+```python
+# Platforms/QemuSbsaPkg/Plugins/QemuRunner/QemuRunner.py
+@staticmethod
+def RunThread(env):
+    tpm_path = env.GetValue("TPM_DEV")
+    tpm_cmd = "swtpm"
+    tpm_args = (
+        f"socket --tpmstate dir={'/'.join(tpm_path.rsplit('/', 1)[:-1])} "
+        f"--ctrl type=unixio,path={tpm_path} --tpm2 --log level=20"
+    )
+    utility_functions.RunCmd(tpm_cmd, tpm_args)
+```
+
+The thread is launched before QEMU starts and joined after QEMU exits. The user is
+prompted to press Ctrl+C to terminate swtpm at shutdown.
+
+### QEMU Arguments
+
+The `QemuCommandBuilder.with_tpm()` method adds:
+
+```
+-chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
+-tpmdev emulator,id=tpm0,chardev=chrtpm
+```
+
+### TPM Initialization (SEC Phase)
+
+When `TPM2_ENABLE=TRUE`, the SEC phase links the non-NULL instance of `Tpm2StartupLib` which calls:
+
+```c
+Tpm2RequestUseTpm();                    // Request locality access via FF-A
+Tpm2Startup(TPM_SU_CLEAR);             // Initialize TPM, clearing PCR banks
+```
+
+This must complete before DXE phase drivers can use the TPM. The SEC phase uses
+`Tpm2DeviceSecLibFfa` and `ArmFfaSecLib` for FF-A communication.
+
+## Communication Flow
+
+Complete path from a shell application to swtpm:
+
+```
+TpmTestApp (UEFI Shell)
+  │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)
+  │ Tcg2Protocol->SetActivePcrBanks(0x02)
+  ▼
+Tcg2Dxe (EFI_TCG2_PROTOCOL)
+  │ Validates bank mask against HashAlgorithmBitmap
+  │ Calls Tcg2PhysicalPresenceLibSubmitRequestToPreOSFunction()
+  │   ↳ MinimumLib: rejects SET_PCR_BANKS → returns EFI_UNSUPPORTED
+  │   ↳ MinimumLib: NO_ACTION (already-active) → writes to NV variable → EFI_SUCCESS
+  ▼
+Tpm2CommandLib (for direct TPM commands like GetCapability)
+  │ Serializes TPM2_CC command structure into byte buffer
+  │ Calls Tpm2SubmitCommand(cmdBuffer, cmdSize, rspBuffer, &rspSize)
+  ▼
+Tpm2DeviceLibFfa — FfaTpm2SubmitCommand()
+  │ PtpCrbTpmCommand(CrbReg = PcdTpmBaseAddress)
+  │
+  │ ┌─ STEP 1: cmdReady ──────────────────────────────────────────┐
+  │ │  MmioWrite32(&CrbReg->CrbControlRequest, PTP_CRB_CONTROL    │
+  │ │              _AREA_REQUEST_COMMAND_READY)                   │
+  │ │  Tpm2ServiceStart(QUALIFIER_COMMAND, 0) ── FF-A ──► MSSP    │
+  │ └─────────────────────────────────────────────────────────────┘
+  │
+  │ ┌─ STEP 2: submit ────────────────────────────────────────────┐
+  │ │  CopyMem(CrbReg->CrbDataBuffer, cmdBuffer, cmdSize)         │
+  │ │  MmioWrite32(&CrbReg->CrbControlStart, 1)                   │
+  │ │  Tpm2ServiceStart(QUALIFIER_COMMAND, 0) ── FF-A ──► MSSP    │
+  │ └─────────────────────────────────────────────────────────────┘
+  │
+  │                    ════ WORLD SWITCH ════
+  │
+  │   MSSP (secure world, partition 0x8002):
+  │     TpmServiceLib: state READY → execute
+  │     TpmServiceStateTranslationLib:
+  │       1. Read command from Internal CRB data buffer
+  │       2. CopyCommandData() → write to External CRB @ 0x60120000 (FIFO)
+  │       3. StartCommand() → trigger TPM execution
+  │       4. CopyResponseData() → read response from External CRB
+  │       5. Write response to Internal CRB data buffer
+  │
+  │                    ════ QEMU MMIO ════
+  │
+  │     QEMU TPM device @ 0x60120000
+  │       └── Unix socket ──── swtpm process
+  │
+  │                    ════ WORLD SWITCH BACK ════
+  │
+  │ ┌─ STEP 3: goIdle ────────────────────────────────────────────┐
+  │ │  Read response from CrbReg->CrbDataBuffer                   │
+  │ │  MmioWrite32(&CrbReg->CrbControlRequest, PTP_CRB_CONTROL    │
+  │ │              _AREA_REQUEST_GO_IDLE)                         │
+  │ │  Tpm2ServiceStart(QUALIFIER_COMMAND, 0) ── FF-A ──► MSSP    │
+  │ └─────────────────────────────────────────────────────────────┘
+  ▼
+Response returned to caller
+```
+
+## PCDs Reference
+
+### Required PCDs (set when TPM2_ENABLE=TRUE)
+
+| PCD | Value | Type | Purpose |
+|-----|-------|------|---------|
+| `PcdTpmBaseAddress` | `0x10000200000` | FixedAtBuild | Internal CRB base address |
+| `PcdTpmMaxAddress` | `0x10000204FFF` | FixedAtBuild | Internal CRB end address (5 localities) |
+| `PcdTpm2HashMask` | `0x02` | DynamicDefault | Hash algorithm filter (SHA256 only) |
+| `PcdTpmInstanceGuid` | `gEfiTpmDeviceInstanceTpm20DtpmGuid` | FixedAtBuild | Selects discrete TPM 2.0 device type |
+| `PcdTpm2AcpiTableRev` | `4` | DynamicHii | ACPI TPM2 table revision |
+| `PcdUserPhysicalPresence` | `FALSE` | FixedAtBuild | No physical user presence assertion |
+
+### Always-Set PCDs
+
+| PCD | Value | Purpose |
+|-----|-------|---------|
+| `PcdMemoryTypeEfiACPIReclaimMemory` | `0x143` | ACPI reclaim memory pages (includes TPM ACPI tables) |
+| `PcdMemoryTypeEfiACPIMemoryNVS` | `0x3C` | ACPI NVS pages (includes CRB region) |
+| `PcdMemoryTypeEfiRuntimeServicesData` | `0x642` | Runtime services data pages |
+| `PcdMemoryTypeEfiRuntimeServicesCode` | `0x424` | Runtime services code pages |
+| `PcdMemoryTypeEfiReservedMemoryType` | `0x505` | Reserved memory pages |
+
+### Conditional PCDs (TPM2_CONFIG_ENABLE=TRUE)
+
+| PCD | Value | Purpose |
+|-----|-------|---------|
+| `PcdTcgPhysicalPresenceInterfaceVer` | `"1.3"` | TCG PPI specification version reported to OS |

--- a/docs/TPM/TpmQemuSbsa.md
+++ b/docs/TPM/TpmQemuSbsa.md
@@ -39,7 +39,7 @@ stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
 The following defines control TPM behavior in `QemuSbsaPkg.dsc`:
 
 | Define | Default | Purpose |
-|--------|---------|---------|
+| -------- | --------- | --------- |
 | `TPM2_ENABLE` | `FALSE` | Master switch. Guards all TPM drivers, libraries, and PCDs. |
 | `TPM2_CONFIG_ENABLE` | `FALSE` | Enables `Tcg2ConfigDxe` HII configuration UI. |
 
@@ -51,7 +51,7 @@ via build options, allowing C code to use `#ifdef TPM2_ENABLE` guards.
 The SBSA platform defines two distinct TPM memory regions:
 
 | Region | Address | Size | Visibility |
-|--------|---------|------|------------|
+| -------- | --------- | ------ | ------------ |
 | Internal CRB | `0x100_00200000` | 0x10 pages | Normal world + Secure world |
 | External CRB | `0x000_60120000` | 0x10 pages | Secure world only |
 
@@ -65,7 +65,7 @@ can locate it through the ACPI TPM2 table.
 
 ## Architecture Overview
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────────────┐
 │ UEFI Firmware (AARCH64)                                                  │
 │                                                                          │
@@ -150,7 +150,7 @@ Two FF-A Secure Partitions are involved in TPM operations.
 Configured in `Platforms/QemuSbsaPkg/fdts/qemu_sbsa_mssp_rust_config.dts`:
 
 | Property | Value |
-|----------|-------|
+| ---------- | ------- |
 | Partition ID | `0x8002` |
 | Exception Level | SEL1 |
 | Execution State | AARCH64 |
@@ -177,7 +177,7 @@ device-regions {
 
 The MSSP publishes three service UUIDs. The TPM service UUID is:
 
-```
+```text
 17b862a4-1806-4faf-86b3-089a58353861
 ```
 
@@ -196,7 +196,7 @@ Key libraries running inside the MSSP:
 Configured in `Platforms/QemuSbsaPkg/fdts/qemu_sbsa_stmm_config.dts`:
 
 | Property | Value |
-|----------|-------|
+| ---------- | ------- |
 | Partition ID | `0x8001` |
 | Exception Level | SEL0 |
 | Execution State | AARCH64 |
@@ -216,7 +216,7 @@ Each locality occupies 0x1000 bytes. The register layout per the TCG PC Client P
 TPM Profile (PTP) specification, defined in `TpmPtp.h`:
 
 | Offset | Register | Description |
-|--------|----------|-------------|
+| -------- | ---------- | ------------- |
 | `0x00` | `LocalityState` | Current locality ownership |
 | `0x08` | `LocalityControl` | Request access, relinquish, seize |
 | `0x0C` | `LocalityStatus` | Granted / been seized status |
@@ -257,7 +257,7 @@ command/response protocol (burst-count reads, data register writes).
 The external CRB connects to the `swtpm` process through QEMU's chardev/tpmdev
 infrastructure:
 
-```
+```text
 QEMU args: -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
            -tpmdev emulator,id=tpm0,chardev=chrtpm
 ```
@@ -287,7 +287,7 @@ partition.
 ### Function IDs
 
 | ID | Name | Direction | Supported |
-|----|------|-----------|-----------|
+| ---- | ------ | ----------- | ----------- |
 | `0x0f000001` | `TPM2_FFA_GET_INTERFACE_VERSION` | NW → SW | YES |
 | `0x0f000101` | `TPM2_FFA_GET_FEATURE_INFO` | NW → SW | NO |
 | `0x0f000201` | `TPM2_FFA_START` | NW → SW | YES |
@@ -299,14 +299,14 @@ partition.
 The `TPM2_FFA_START` function carries a qualifier in Arg1:
 
 | Qualifier | Value | Purpose |
-|-----------|-------|---------|
+| ----------- | ------- | --------- |
 | `TPM2_FFA_START_FUNC_QUALIFIER_COMMAND` | `0x0` | Execute a CRB state transition (cmdReady, start, or goIdle) |
 | `TPM2_FFA_START_FUNC_QUALIFIER_LOCALITY` | `0x1` | Request or relinquish locality access |
 
 The `TPM2_FFA_MANAGE_LOCALITY` function carries a qualifier in Arg1:
 
 | Qualifier | Value | Purpose |
-|-----------|-------|---------|
+| ----------- | ------- | --------- |
 | `TPM2_FFA_MANAGE_LOCALITY_OPEN` | `0x0` | Allows access to a locality |
 | `TPM2_FFA_MANAGE_LOCALITY_CLOSE` | `0x1` | Prevents access to a locality |
 
@@ -325,39 +325,38 @@ relinquished is not the current active locality, a DENIED error is returned.
 
 A single TPM command requires multiple FF-A round trips:
 
-```
-Normal World                              Secure World (MSSP)
-────────────                              ───────────────────
+```mermaid
+sequenceDiagram
+    participant NW as Normal World
+    participant SW as Secure World (MSSP)
 
-1. Write LocalityControl = request access
-   FFA DirectReq2(START, LOCALITY) ──────► LocalityX becomes active
-                                   ◄────── FFA DirectResp2(SUCCESS)
+    Note over NW: Write LocalityControl = request access
+    NW->>SW: FFA DirectReq2(START, LOCALITY)
+    Note over SW: LocalityX becomes active
+    SW-->>NW: FFA DirectResp2(SUCCESS)
 
-2. Write CrbControlRequest = cmdReady
-   FFA DirectReq2(START, COMMAND) ──────► State: IDLE → READY
-                                          (prepare external TPM)
-                                  ◄────── FFA DirectResp2(SUCCESS)
+    Note over NW: Write CrbControlRequest = cmdReady
+    NW->>SW: FFA DirectReq2(START, COMMAND)
+    Note over SW: State: IDLE → READY<br/>(prepare external TPM)
+    SW-->>NW: FFA DirectResp2(SUCCESS)
 
-3. Write command to CrbDataBuffer
-   Write CrbControlStart = 1
-   FFA DirectReq2(START, COMMAND) ──────► State: READY → COMPLETE
-                                          • Copy cmd from Internal CRB
-                                          • Write cmd to External CRB
-                                          • Trigger external TPM
-                                          • Read response from External CRB
-                                          • Copy response to Internal CRB
-                                  ◄────── FFA DirectResp2(SUCCESS)
+    Note over NW: Write command to CrbDataBuffer<br/>Write CrbControlStart = 1
+    NW->>SW: FFA DirectReq2(START, COMMAND)
+    Note over SW: State: READY → COMPLETE<br/>• Copy cmd from Internal CRB<br/>• Write cmd to External CRB<br/>• Trigger external TPM<br/>• Read response from External CRB<br/>• Copy response to Internal CRB
+    SW-->>NW: FFA DirectResp2(SUCCESS)
 
-4. Read response from CrbDataBuffer
-   Write CrbControlRequest = goIdle
-   FFA DirectReq2(START, COMMAND) ──────► State: COMPLETE → IDLE
-                                          (idle external TPM)
-                                  ◄────── FFA DirectResp2(SUCCESS)
+    Note over NW: Read response from CrbDataBuffer<br/>Write CrbControlRequest = goIdle
+    NW->>SW: FFA DirectReq2(START, COMMAND)
+    Note over SW: State: COMPLETE → IDLE<br/>(idle external TPM)
+    SW-->>NW: FFA DirectResp2(SUCCESS)
 
-**OPTIONAL**
-5. Write LocalityControl = relinquish access
-   FFA DirectReq2(START, LOCALITY) ──────► LocalityX is relinquished
-                                   ◄────── FFA DirectResp2(SUCCESS)
+    rect rgba(200, 200, 200, 0.2)
+        Note over NW,SW: OPTIONAL
+        Note over NW: Write LocalityControl = relinquish access
+        NW->>SW: FFA DirectReq2(START, LOCALITY)
+        Note over SW: LocalityX is relinquished
+        SW-->>NW: FFA DirectResp2(SUCCESS)
+    end
 ```
 
 If the secure partition is preempted by a non-secure interrupt during processing, the FF-A
@@ -421,7 +420,7 @@ Tcg2Dxe uses a pluggable hash library architecture based on `HashLibBaseCryptoRo
 ### Hash Algorithm Bitmask Values
 
 | Algorithm | Bit | Value |
-|-----------|-----|-------|
+| ----------- | ----- | ------- |
 | SHA1 | BIT0 | `0x01` |
 | SHA256 | BIT1 | `0x02` |
 | SHA384 | BIT2 | `0x04` |
@@ -430,7 +429,7 @@ Tcg2Dxe uses a pluggable hash library architecture based on `HashLibBaseCryptoRo
 
 ### Filtering Chain
 
-```
+```text
 PcdTpm2HashMask (0x02)
         │
         ▼
@@ -484,7 +483,7 @@ variable store in StMM.
 Published by `Tcg2AcpiFfa.c`:
 
 | Field | Value |
-|-------|-------|
+| ------- | ------- |
 | Start Method | CRB with FF-A (`0x0C`) |
 | Control Area Address | `PcdTpmBaseAddress + 0x40` |
 | Command Buffer | `PcdTpmBaseAddress + 0x80`, size `0xF80` |
@@ -559,7 +558,7 @@ prompted to press Ctrl+C to terminate swtpm at shutdown.
 
 The `QemuCommandBuilder.with_tpm()` method adds:
 
-```
+```text
 -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock
 -tpmdev emulator,id=tpm0,chardev=chrtpm
 ```
@@ -580,7 +579,7 @@ This must complete before DXE phase drivers can use the TPM. The SEC phase uses
 
 Complete path from a shell application to swtpm:
 
-```
+```text
 TpmTestApp (UEFI Shell)
   │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)
   │ Tcg2Protocol->SetActivePcrBanks(0x02)
@@ -643,7 +642,7 @@ Response returned to caller
 ### Required PCDs (set when TPM2_ENABLE=TRUE)
 
 | PCD | Value | Type | Purpose |
-|-----|-------|------|---------|
+| ----- | ------- | ------ | --------- |
 | `PcdTpmBaseAddress` | `0x10000200000` | FixedAtBuild | Internal CRB base address |
 | `PcdTpmMaxAddress` | `0x10000204FFF` | FixedAtBuild | Internal CRB end address (5 localities) |
 | `PcdTpm2HashMask` | `0x02` | DynamicDefault | Hash algorithm filter (SHA256 only) |
@@ -654,7 +653,7 @@ Response returned to caller
 ### Always-Set PCDs
 
 | PCD | Value | Purpose |
-|-----|-------|---------|
+| ----- | ------- | --------- |
 | `PcdMemoryTypeEfiACPIReclaimMemory` | `0x143` | ACPI reclaim memory pages (includes TPM ACPI tables) |
 | `PcdMemoryTypeEfiACPIMemoryNVS` | `0x3C` | ACPI NVS pages (includes CRB region) |
 | `PcdMemoryTypeEfiRuntimeServicesData` | `0x642` | Runtime services data pages |
@@ -664,5 +663,5 @@ Response returned to caller
 ### Conditional PCDs (TPM2_CONFIG_ENABLE=TRUE)
 
 | PCD | Value | Purpose |
-|-----|-------|---------|
+| ----- | ------- | --------- |
 | `PcdTcgPhysicalPresenceInterfaceVer` | `"1.3"` | TCG PPI specification version reported to OS |

--- a/docs/TPM/TpmTestAppQemu.md
+++ b/docs/TPM/TpmTestAppQemu.md
@@ -1,8 +1,8 @@
 # TpmTestApp on QEMU Platforms
 
 Platform-specific guidance for running
-[TpmTestApp](../MU_BASECORE/SecurityPkg/Applications/TpmTestApp/TpmTestApp.md) on the
-QEMU Q35 and SBSA platforms.
+[TpmTestApp](https://github.com/microsoft/mu_basecore/blob/release/202511/SecurityPkg/Applications/TpmTestApp/TpmTestApp.md)
+on the QEMU Q35 and SBSA platforms.
 
 ## Table of Contents
 

--- a/docs/TPM/TpmTestAppQemu.md
+++ b/docs/TPM/TpmTestAppQemu.md
@@ -1,0 +1,265 @@
+# TpmTestApp on QEMU Platforms
+
+Platform-specific guidance for running
+[TpmTestApp](../MU_BASECORE/SecurityPkg/Applications/TpmTestApp/TpmTestApp.md) on the
+QEMU Q35 and SBSA platforms.
+
+## Table of Contents
+
+- [FDF Placement](#fdf-placement)
+- [Protocol Availability](#protocol-availability)
+- [Running on QEMU SBSA](#running-on-qemu-sbsa)
+- [Running on QEMU Q35](#running-on-qemu-q35)
+- [Hash Algorithm Configuration](#hash-algorithm-configuration)
+- [Expected Behavior with MinimumLib](#expected-behavior-with-minimumlib)
+- [Event Log and Replay](#event-log-and-replay)
+- [Findings](#findings)
+
+## FDF Placement
+
+On SBSA, add the INF to `FV.FvMain`. On Q35, add it to `FV.DXEFV`:
+
+```ini
+INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+```
+
+## Protocol Availability
+
+The `EFI_TCG2_PROTOCOL` is installed by `Tcg2Dxe.efi`, which only loads when
+`TPM_ENABLE=TRUE` (Q35) or `TPM2_ENABLE=TRUE` (SBSA).
+
+## Running on QEMU SBSA
+
+On SBSA, the TpmTestApp is placed directly in the firmware volume, which is mapped as an
+`FSx:` device in the UEFI shell. Build with:
+
+```bash
+stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
+  BLD_*_TPM2_ENABLE=TRUE \
+  TPM_DEV=/tmp/mytpm1/swtpm-sock
+```
+
+At the UEFI shell, run:
+
+```text
+Shell> TpmTestApp.efi help
+Shell> TpmTestApp.efi info
+Shell> TpmTestApp.efi eventlog
+Shell> TpmTestApp.efi replay
+```
+
+Or navigate to the correct FS mapping first:
+
+```text
+Shell> map -r
+Shell> FS0:
+FS0:\> TpmTestApp.efi info
+```
+
+## Running on QEMU Q35
+
+On Q35, shell applications are loaded from a virtual drive (FAT filesystem image), not
+directly from the firmware volume. The `FILE_REGEX` build parameter controls which
+binaries are copied to the virtual drive:
+
+```bash
+stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
+  BLD_*_TPM_ENABLE=TRUE \
+  TPM_DEV=/tmp/mytpm1/swtpm-sock \
+  FILE_REGEX=TpmTestApp.efi
+```
+
+At the UEFI shell, find the virtual drive's FS mapping (typically backed by a PCI device,
+not `Fv(...)`) and run:
+
+```text
+Shell> map -r
+Shell> FS0:
+FS0:\> TpmTestApp.efi info
+```
+
+If the app is not found, verify the virtual drive was created with the binary:
+
+```text
+Shell> FS0:
+FS0:\> dir
+```
+
+## Hash Algorithm Configuration
+
+Both QEMU platforms set `PcdTpm2HashMask` to `0x02` (SHA256 only). This means the app
+will typically only see SHA256 as supported and active, even though swtpm may support all
+five algorithms. To see additional algorithms, update `PcdTpm2HashMask` in the platform
+DSC.
+
+## Expected Behavior with MinimumLib
+
+Both QEMU platforms use `DxeTcg2PhysicalPresenceMinimumLib` when TPM is enabled. This
+library has specific behaviors that affect TpmTestApp results:
+
+### `setpcr` with Already-Active Banks
+
+When the requested banks match the currently active banks, `Tcg2Dxe` sends
+`TCG2_PHYSICAL_PRESENCE_NO_ACTION` to the PP library. MinimumLib processes `NO_ACTION`
+successfully, returning `EFI_SUCCESS`.
+
+```text
+Shell> TpmTestApp setpcr 0x2    (SHA256 already active)
+Submitting SetActivePcrBanks with parameter 2
+Status: Success
+Request submitted. Changes will take effect after reboot.
+```
+
+### `setpcr` with Different Banks
+
+When the requested banks differ from active banks, `Tcg2Dxe` sends
+`TCG2_PHYSICAL_PRESENCE_SET_PCR_BANKS` to the PP library. MinimumLib rejects this
+operation as it only supports Clear operations.
+
+```text
+Shell> TpmTestApp setpcr 0x4    (SHA384, not currently active)
+Submitting SetActivePcrBanks with parameter 4
+Status: Unsupported
+SetActivePcrBanks failed.
+```
+
+This is **expected and correct behavior** — MinimumLib is designed to block PCR bank
+changes.
+
+### `logall` Expected Behavior
+
+If the platform only has SHA256 registered (default), `logall` requests the same bank
+that's already active, resulting in a `NO_ACTION` → `EFI_SUCCESS`. If additional
+algorithms were registered, it would request banks different from the active set,
+triggering a `SET_PCR_BANKS` rejection.
+
+### `lastresponse` Expected Behavior
+
+Reports the result stored in the `Tcg2PhysicalPresence` NV variable by
+`ProcessRequest`. If no prior `SetActivePcrBanks` was processed through a reboot cycle,
+the response will show no operation present.
+
+```text
+Shell> TpmTestApp lastresponse
+  Operation present: NO
+  Response code:     0
+```
+
+## Event Log and Replay
+
+### `eventlog` on QEMU
+
+The `eventlog` command dumps the crypto-agile TCG2 event log. On QEMU with the default
+SHA256-only configuration, each event contains a single SHA256 digest.
+
+```text
+Shell> TpmTestApp.efi eventlog
+
+[TCG2 Event Log]
+
+Spec ID Event: 1 algorithm(s)
+  SHA256 (alg 0xb, digest 32 bytes)
+
+Event 1: PCR 0 EV_S_CRTM_VERSION (0x8)
+  SHA256: ab cd ef ...
+  Event data: 2 bytes
+Event 2: PCR 0 EV_EFI_PLATFORM_FIRMWARE_BLOB (0x80000008)
+  SHA256: 01 23 45 ...
+  Event data: 16 bytes
+...
+Total: N event(s)
+```
+
+If `PcdTpm2HashMask` is updated to enable additional algorithms (e.g., `0x06` for
+SHA256 + SHA384), each event will contain multiple digests — one per active algorithm.
+
+### `replay` on QEMU
+
+The `replay` command replays extend operations from the event log to compute expected
+PCR values, then reads the actual PCR values from the TPM via `SubmitCommand` and
+compares them.
+
+```text
+Shell> TpmTestApp.efi replay
+
+[Event Log Replay]
+
+Replayed N event(s) across 1 algorithm(s).
+
+PCR 0:
+  SHA256 Replayed: aa bb cc ...
+  SHA256 Actual:   aa bb cc ...
+  Result: PASS
+
+PCR 1:
+  SHA256 Replayed: 11 22 33 ...
+  SHA256 Actual:   11 22 33 ...
+  Result: PASS
+
+...
+Summary: M PCR bank(s) verified, M PASS, 0 FAIL
+```
+
+On a freshly booted QEMU platform with swtpm, all PCRs should show `PASS`. A `FAIL`
+indicates that either the event log is incomplete (e.g., truncated) or an extend
+operation occurred outside the logged event flow.
+
+### Replay with Multiple Algorithms
+
+When multiple hash algorithms are active, the replay verifies each algorithm
+independently. Algorithms not supported by `BaseCryptLib` (e.g., SM3_256) are skipped
+with a message:
+
+```text
+PCR 0:
+  SHA256 Replayed: ...
+  SHA256 Actual:   ...
+  Result: PASS
+  SM3_256: (replay not supported, skipped)
+```
+
+### Truncated Event Log
+
+If the firmware's event log buffer was exhausted, the `eventlog` and `replay` commands
+print a warning:
+
+```text
+Warning: Event log was truncated.
+```
+
+For `replay`, a truncated log means the replayed PCR values will not include all
+extensions, so mismatches are expected.
+
+## Findings
+
+**April 2026:**
+
+Manually updating Tpm2HashMask in the platform .dsc is dangerous. On Q35, PEI will
+pick up the change and auto enable/disable any PCR banks that differ from the current
+active banks in the TPM. (See Tcg2Pei - SyncPcrAllocationsAndPcrMask) If the platform
+also disables (i.e. removes) any of the supported hashing algorithms from the platform
+.dsc there are no safeguards to prevent the TPM from enabling/disabling any active banks
+based on platform support. Because of this there can be active banks that will show up
+as active when querying the TPM but will not show up as active in the Tcg2Protocol call.
+
+Example:
+
+- Tpm2HashMask is updated to 0x06 (i.e. SHA256 + SHA384 supported).
+- SHA384 support is removed from Tcg2Pei and Tcg2Dxe.
+- Build/Run the Q35 platform.
+- TPM reports SHA256 as the only active PCR bank.
+- Tcg2Pei recognizes there is a mismatch between platform support (i.e. Tpm2HashMask)
+  and TPM active banks. Activates SHA384 into a ResetCold.
+- TPM reports SHA256 + SHA384 as active PCR banks.
+- HashLibCryptoRouterPei and HashLibCryptoRouterDxe set PcdTcg2HashAlgorithmBitmap based on
+  successfully registered hash algorithms.
+- Tcg2Pei registers SHA256 but is unable to register SHA384.
+- Tcg2Dxe registers SHA256 but is unable to register SHA384.
+- Tcg2Dxe sets local variables based on what the TPM reports and PcdTcg2HashAlgorithmBitmap.
+
+  ```C
+  mTcgDxeData.BsCap.HashAlgorithmBitmap = TpmHashAlgorithmBitmap & PcdGet32 (PcdTcg2HashAlgorithmBitmap);
+  mTcgDxeData.BsCap.ActivePcrBanks      = ActivePCRBanks & PcdGet32 (PcdTcg2HashAlgorithmBitmap);
+  ```
+
+- Tcg2Protocol is installed with only SHA256 support reported even though SHA384 is active.


### PR DESCRIPTION
## Description

Updating platform level to re-enable TPM on Q35. Add TpmTestApp support for both Q35 and SBSA. Updated the platform to include mapping the CRB region for Q35. Updated the QemuRunner for Q35 to include automatically setting up and running the swtpm. Updated the DeviceBootManagerLib to set up the physical presence variables which are used in the TpmTestApp when attempting to activate PCR banks. Added documentation regarding the TPM on Q35 and SBSA as well as a document about the TpmTestApp and its use on both platforms. Updating the MU_BASECORE submodule to include the latest release. Updated the ACPI NV Reclaim memory to support the TPM on Q35. Added a CI workflow to build and run Q35 with the TPM enabled.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Built both QEMU Q35 and SBSA with TPM enabled (TPM2_ENABLE -> Q35 & TPM_ENABLE -> SBSA). Verified TPM functionality. Verified TpmTestApp functionality.

## Integration Instructions

N/A
