### PR TITLE
Add DP shell command to Q35 & SBSA platforms

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1086,6 +1086,10 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
     <PcdsFixedAtBuild>
       gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
   }
+  ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf {
+    <PcdsFixedAtBuild>
+      gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
+  }
   QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf {
     <PcdsFixedAtBuild>
       gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -371,6 +371,7 @@ INF  MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
 INF  ShellPkg/DynamicCommand/TftpDynamicCommand/TftpDynamicCommand.inf
 INF  ShellPkg/DynamicCommand/HttpDynamicCommand/HttpDynamicCommand.inf
 INF  ShellPkg/DynamicCommand/VariablePolicyDynamicCommand/VariablePolicyDynamicCommand.inf
+INF  ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
 INF  QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
 
 #

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1128,6 +1128,10 @@
     <PcdsFixedAtBuild>
       gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
   }
+  ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf {
+    <PcdsFixedAtBuild>
+      gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE
+  }
   QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf {
     <PcdsFixedAtBuild>
       gEfiShellPkgTokenSpaceGuid.PcdShellLibAutoInitialize|FALSE

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -276,6 +276,7 @@ READ_LOCK_STATUS   = TRUE
   INF ShellPkg/DynamicCommand/TftpDynamicCommand/TftpDynamicCommand.inf
   INF ShellPkg/DynamicCommand/HttpDynamicCommand/HttpDynamicCommand.inf
   INF ShellPkg/DynamicCommand/VariablePolicyDynamicCommand/VariablePolicyDynamicCommand.inf
+  INF ShellPkg/DynamicCommand/DpDynamicCommand/DpDynamicCommand.inf
   INF QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
 
   INF MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerDxe.inf


### PR DESCRIPTION
## Description

The `dp` command in the shell is used to parse the FBPT in the shell which is useful for testing and checking the performance code. This commit adds the `dp` command to the Q35 and SBSA platforms.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot to shell and ran `dp`

## Integration Instructions

N/A
