### PR TITLE
Rename TpmTestApp to TpmShellApp

### DIFF
--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -1308,15 +1308,12 @@ QemuQ35Pkg/Library/ResetSystemLib/StandaloneMmResetSystemLib.inf
       MfciDeviceIdSupportLib|MfciPkg/Library/MfciDeviceIdSupportLibSmbios/MfciDeviceIdSupportLibSmbios.inf
   }
 
-# The TpmTestApp can run without TPM enabled. It will report that the
+# The TpmShellApp can run without TPM enabled. It will report that the
 # Tcg2Protocol was not installed, however, it really isn't meant to run
-# without TPM enabled. TPM_TEST_APP_ENABLE prevents an issue in CI where
-# all TestApps are auto included to run.
+# without TPM enabled.
 !if $(TPM_ENABLE) == TRUE
-!if $(TPM_TEST_APP_ENABLE) == TRUE
-  # TPM test application to test PCR bank operations via TCG2 Protocol
-  SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
-!endif
+  # TPM shell application to test PCR bank operations via TCG2 Protocol
+  SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
 
 !include TpmTestingPkg/TpmReplay.dsc.inc

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.fdf
@@ -461,9 +461,7 @@ INF  SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDxe.inf
 !endif
 
 !if $(TPM_ENABLE) == TRUE
-!if $(TPM_TEST_APP_ENABLE) == TRUE
-INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
-!endif
+INF SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
 
 INF  AdvLoggerPkg/AdvancedFileLogger/AdvancedFileLogger.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1245,7 +1245,6 @@
   SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
 
-
 ###################################################################################################
 #
 # BuildOptions Section - Define the module specific tool chain flags that should be used as

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1244,7 +1244,7 @@
   # TPM shell application to test PCR bank operations via TCG2 Protocol
   SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
-!endif
+
 
 ###################################################################################################
 #

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -1237,14 +1237,12 @@
   # FF-A test application to test the FF-A interface
   FfaFeaturePkg/Applications/FfaPartitionTest/FfaPartitionTestApp.inf
 
-# The TpmTestApp can run without TPM enabled. It will report that the
+# The TpmShellApp can run without TPM enabled. It will report that the
 # Tcg2Protocol was not installed, however, it really isn't meant to run
-# without TPM enabled. TPM_TEST_APP_ENABLE prevents an issue in CI where
-# all TestApps are auto included to run.
+# without TPM enabled.
 !if $(TPM2_ENABLE) == TRUE
-!if $(TPM_TEST_APP_ENABLE) == TRUE
-  # TPM test application to test PCR bank operations via TCG2 Protocol
-  SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+  # TPM shell application to test PCR bank operations via TCG2 Protocol
+  SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
 !endif
 

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -282,7 +282,6 @@ READ_LOCK_STATUS   = TRUE
   INF SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
 
-
   INF MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerDxe.inf
   INF MsGraphicsPkg/RenderingEngineDxe/RenderingEngineDxe.inf
   INF MsGraphicsPkg/OnScreenKeyboardDxe/OnScreenKeyboardDxe.inf

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -279,8 +279,7 @@ READ_LOCK_STATUS   = TRUE
   INF QemuPkg/LinuxInitrdDynamicShellCommand/LinuxInitrdDynamicShellCommand.inf
 
 !if $(TPM2_ENABLE) == TRUE
-!if $(TPM_TEST_APP_ENABLE) == TRUE
-  INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+  INF SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
 !endif
 

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.fdf
@@ -281,7 +281,7 @@ READ_LOCK_STATUS   = TRUE
 !if $(TPM2_ENABLE) == TRUE
   INF SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 !endif
-!endif
+
 
   INF MsGraphicsPkg/SimpleWindowManagerDxe/SimpleWindowManagerDxe.inf
   INF MsGraphicsPkg/RenderingEngineDxe/RenderingEngineDxe.inf

--- a/docs/TPM/TpmQemuQ35.md
+++ b/docs/TPM/TpmQemuQ35.md
@@ -91,7 +91,7 @@ The base address comes from the SecurityPkg package declaration default
 │                                                                          │
 │  ┌─── UEFI Shell ─────────────────────────────────────────────────────┐  │
 │  │                                                                    │  │
-│  │  UEFI Shell / OS / TpmTestApp                                      │  │
+│  │  UEFI Shell / OS / TpmShellApp                                     │  │
 │  │    │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)                    │  │
 │  │    │ Tcg2Protocol->GetCapability / SetActivePcrBanks / etc.        │  │
 │  └────┼───────────────────────────────────────────────────────────────┘  │
@@ -354,7 +354,7 @@ to the Q35 chipset at the standard address `0xFED40000`.
 Complete path from a shell application to swtpm:
 
 ```text
-TpmTestApp (UEFI Shell)
+TpmShellApp (UEFI Shell)
   │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)
   │ Tcg2Protocol->SetActivePcrBanks(0x02)
   ▼

--- a/docs/TPM/TpmQemuSbsa.md
+++ b/docs/TPM/TpmQemuSbsa.md
@@ -102,7 +102,7 @@ can locate it through the ACPI TPM2 table.
 │                                                                          │
 │  ┌─── UEFI Shell ─────────────────────────────────────────────────────┐  │
 │  │                                                                    │  │
-│  │  UEFI Shell / OS / TpmTestApp                                      │  │
+│  │  UEFI Shell / OS / TpmShellApp                                     │  │
 │  │    │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)                    │  │
 │  │    │ Tcg2Protocol->GetCapability / SetActivePcrBanks / etc.        │  │
 │  └────┼───────────────────────────────────────────────────────────────┘  │
@@ -580,7 +580,7 @@ This must complete before DXE phase drivers can use the TPM. The SEC phase uses
 Complete path from a shell application to swtpm:
 
 ```text
-TpmTestApp (UEFI Shell)
+TpmShellApp (UEFI Shell)
   │ gBS->LocateProtocol(&gEfiTcg2ProtocolGuid)
   │ Tcg2Protocol->SetActivePcrBanks(0x02)
   ▼

--- a/docs/TPM/TpmShellAppQemu.md
+++ b/docs/TPM/TpmShellAppQemu.md
@@ -1,7 +1,7 @@
-# TpmTestApp on QEMU Platforms
+# TpmShellApp on QEMU Platforms
 
 Platform-specific guidance for running
-[TpmTestApp](https://github.com/microsoft/mu_basecore/blob/release/202511/SecurityPkg/Applications/TpmTestApp/TpmTestApp.md)
+[TpmShellApp](https://github.com/microsoft/mu_basecore/blob/release/202511/SecurityPkg/Applications/TpmShellApp/TpmShellApp.md)
 on the QEMU Q35 and SBSA platforms.
 
 ## Table of Contents
@@ -20,7 +20,7 @@ on the QEMU Q35 and SBSA platforms.
 On SBSA, add the INF to `FV.FvMain`. On Q35, add it to `FV.DXEFV`:
 
 ```ini
-INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+INF SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 ```
 
 ## Protocol Availability
@@ -30,7 +30,7 @@ The `EFI_TCG2_PROTOCOL` is installed by `Tcg2Dxe.efi`, which only loads when
 
 ## Running on QEMU SBSA
 
-On SBSA, the TpmTestApp is placed directly in the firmware volume, which is mapped as an
+On SBSA, the TpmShellApp is placed directly in the firmware volume, which is mapped as an
 `FSx:` device in the UEFI shell. Build with:
 
 ```bash
@@ -42,10 +42,10 @@ stuart_build -c Platforms/QemuSbsaPkg/PlatformBuild.py --FlashRom \
 At the UEFI shell, run:
 
 ```text
-Shell> TpmTestApp.efi help
-Shell> TpmTestApp.efi info
-Shell> TpmTestApp.efi eventlog
-Shell> TpmTestApp.efi replay
+Shell> TpmShellApp.efi help
+Shell> TpmShellApp.efi info
+Shell> TpmShellApp.efi eventlog
+Shell> TpmShellApp.efi replay
 ```
 
 Or navigate to the correct FS mapping first:
@@ -53,7 +53,7 @@ Or navigate to the correct FS mapping first:
 ```text
 Shell> map -r
 Shell> FS0:
-FS0:\> TpmTestApp.efi info
+FS0:\> TpmShellApp.efi info
 ```
 
 ## Running on QEMU Q35
@@ -66,7 +66,7 @@ binaries are copied to the virtual drive:
 stuart_build -c Platforms/QemuQ35Pkg/PlatformBuild.py --FlashRom \
   BLD_*_TPM_ENABLE=TRUE \
   TPM_DEV=/tmp/mytpm1/swtpm-sock \
-  FILE_REGEX=TpmTestApp.efi
+  FILE_REGEX=TpmShellApp.efi
 ```
 
 At the UEFI shell, find the virtual drive's FS mapping (typically backed by a PCI device,
@@ -75,7 +75,7 @@ not `Fv(...)`) and run:
 ```text
 Shell> map -r
 Shell> FS0:
-FS0:\> TpmTestApp.efi info
+FS0:\> TpmShellApp.efi info
 ```
 
 If the app is not found, verify the virtual drive was created with the binary:
@@ -95,7 +95,7 @@ DSC.
 ## Expected Behavior with MinimumLib
 
 Both QEMU platforms use `DxeTcg2PhysicalPresenceMinimumLib` when TPM is enabled. This
-library has specific behaviors that affect TpmTestApp results:
+library has specific behaviors that affect TpmShellApp results:
 
 ### `setpcr` with Already-Active Banks
 
@@ -104,7 +104,7 @@ When the requested banks match the currently active banks, `Tcg2Dxe` sends
 successfully, returning `EFI_SUCCESS`.
 
 ```text
-Shell> TpmTestApp setpcr 0x2    (SHA256 already active)
+Shell> TpmShellApp setpcr 0x2    (SHA256 already active)
 Submitting SetActivePcrBanks with parameter 2
 Status: Success
 Request submitted. Changes will take effect after reboot.
@@ -117,7 +117,7 @@ When the requested banks differ from active banks, `Tcg2Dxe` sends
 operation as it only supports Clear operations.
 
 ```text
-Shell> TpmTestApp setpcr 0x4    (SHA384, not currently active)
+Shell> TpmShellApp setpcr 0x4    (SHA384, not currently active)
 Submitting SetActivePcrBanks with parameter 4
 Status: Unsupported
 SetActivePcrBanks failed.
@@ -140,7 +140,7 @@ Reports the result stored in the `Tcg2PhysicalPresence` NV variable by
 the response will show no operation present.
 
 ```text
-Shell> TpmTestApp lastresponse
+Shell> TpmShellApp lastresponse
   Operation present: NO
   Response code:     0
 ```
@@ -153,7 +153,7 @@ The `eventlog` command dumps the crypto-agile TCG2 event log. On QEMU with the d
 SHA256-only configuration, each event contains a single SHA256 digest.
 
 ```text
-Shell> TpmTestApp.efi eventlog
+Shell> TpmShellApp.efi eventlog
 
 [TCG2 Event Log]
 
@@ -180,7 +180,7 @@ PCR values, then reads the actual PCR values from the TPM via `SubmitCommand` an
 compares them.
 
 ```text
-Shell> TpmTestApp.efi replay
+Shell> TpmShellApp.efi replay
 
 [Event Log Replay]
 


### PR DESCRIPTION
## Description

Renamed TpmTestApp to TpmShellApp. This avoids the need for the TPM_TEST_APP_ENABLE flag which was added because CI views anything named *TestApp as a unit test app which causes issues as the TpmTestApp is not a unit test app. Updated MU_BASECORE to point to the latest releast which has the updated TpmTestApp rename changes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built QEMU SBSA and Q35 with TPM/TPM2_ENABLE==TRUE. Verified the TpmShellApp functionality.

## Integration Instructions

N/A
