### PR TITLE
QemuQ35Pkg: Integrate PEI memory bins [Rebase & FF]

### DIFF
--- a/Platforms/QemuQ35Pkg/PlatformPei/MemTypeInfo.c
+++ b/Platforms/QemuQ35Pkg/PlatformPei/MemTypeInfo.c
@@ -187,6 +187,8 @@ OnReadOnlyVariable2Available (
 
   RefreshMemTypeInfo (Ppi);
   BuildMemTypeInfoHob ();
+  CompleteInitialization ();
+
   return EFI_SUCCESS;
 }
 
@@ -201,12 +203,13 @@ STATIC CONST EFI_PEI_NOTIFY_DESCRIPTOR  mReadOnlyVariable2Notify = {
   OnReadOnlyVariable2Available              // Notify
 };
 
-VOID
+EFI_STATUS
 MemTypeInfoInitialization (
   VOID
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS                       Status;
+  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *ReadOnlyVariable2;
 
   if (!FeaturePcdGet (PcdSmmSmramRequire)) {
     //
@@ -214,7 +217,22 @@ MemTypeInfoInitialization (
     // the default memory type information HOB right away.
     //
     BuildMemTypeInfoHob ();
-    return;
+    return EFI_SUCCESS;
+  }
+
+  Status = PeiServicesLocatePpi (
+             &gEfiPeiReadOnlyVariable2PpiGuid,
+             0,
+             NULL,
+             (VOID **)&ReadOnlyVariable2
+             );
+  if (!EFI_ERROR (Status)) {
+    //
+    // EFI_PEI_READ_ONLY_VARIABLE2_PPI is already available; use it now.
+    //
+    RefreshMemTypeInfo (ReadOnlyVariable2);
+    BuildMemTypeInfoHob ();
+    return EFI_SUCCESS;
   }
 
   Status = PeiServicesNotifyPpi (&mReadOnlyVariable2Notify);
@@ -228,4 +246,10 @@ MemTypeInfoInitialization (
     ASSERT (FALSE);
     CpuDeadLoop ();
   }
+
+  //
+  // Return that we're not ready yet so that the dispatcher can dispatch
+  // the variable PEIM first.
+  //
+  return EFI_NOT_READY;
 }

--- a/Platforms/QemuQ35Pkg/PlatformPei/Platform.c
+++ b/Platforms/QemuQ35Pkg/PlatformPei/Platform.c
@@ -207,9 +207,9 @@ MemMapInitialization (
   AddIoMemoryBaseSizeHob (0xFED00000, SIZE_4KB);
 
   // Only generate this HOB if TPM is enabled
-  #ifdef TPM_ENABLE
+ #ifdef TPM_ENABLE
   AddIoMemoryBaseSizeHob (0xFED40000, SIZE_4KB);
-  #endif
+ #endif
 
   if (mHostBridgeDevId == INTEL_Q35_MCH_DEVICE_ID) {
     AddIoMemoryBaseSizeHob (ICH9_ROOT_COMPLEX_BASE, SIZE_16KB);
@@ -820,6 +820,36 @@ PublishPatinaPerformanceConfigHob (
     ));
 }
 
+VOID
+CompleteInitialization (
+  VOID
+  )
+{
+  PublishPeiMemory ();
+  QemuUc32BaseInitialization ();
+  InitializeRamRegions ();
+
+  if (!FeaturePcdGet (PcdSmmSmramRequire)) {
+    ReserveEmuVariableNvStore ();
+  }
+
+  PeiFvInitialization ();
+  MemMapInitialization ();
+  NoexecDxeInitialization ();
+
+  InstallClearCacheCallback ();
+  AmdSevInitialize ();
+  MiscInitialization ();
+  InstallFeatureControlCallback ();
+
+  if (FeaturePcdGet (PcdSmmSmramRequire)) {
+    RelocateSmBase ();
+  }
+
+  PublishV2ResourceHobs ();
+  PublishPatinaPerformanceConfigHob ();
+}
+
 /**
   Perform Platform PEI initialization.
 
@@ -836,6 +866,8 @@ InitializePlatform (
   IN CONST EFI_PEI_SERVICES     **PeiServices
   )
 {
+  EFI_STATUS  Status;
+
   // MU_CHANGE START
   DXE_MEMORY_PROTECTION_SETTINGS  DxeSettings;
   MM_MEMORY_PROTECTION_SETTINGS   MmSettings;
@@ -889,31 +921,18 @@ InitializePlatform (
     Q35SmramAtDefaultSmbaseInitialization ();
   }
 
-  PublishPeiMemory ();
-
-  QemuUc32BaseInitialization ();
-
-  InitializeRamRegions ();
-
-  if (!FeaturePcdGet (PcdSmmSmramRequire)) {
-    ReserveEmuVariableNvStore ();
+  Status = MemTypeInfoInitialization ();
+  if (EFI_ERROR (Status)) {
+    //
+    // Failing here is okay, it just means that the variable read PPI wasn't
+    // found, so we need to return EFI_SUCCESS here and let the dispatcher
+    // dispatch the variable PEIM first and then we'll get called back to
+    // finish initialization.
+    //
+    return EFI_SUCCESS;
   }
 
-  PeiFvInitialization ();
-  MemTypeInfoInitialization ();
-  MemMapInitialization ();
-  NoexecDxeInitialization ();
-
-  InstallClearCacheCallback ();
-  AmdSevInitialize ();
-  MiscInitialization ();
-  InstallFeatureControlCallback ();
-  if (FeaturePcdGet (PcdSmmSmramRequire)) {
-    RelocateSmBase ();
-  }
-
-  PublishV2ResourceHobs ();
-  PublishPatinaPerformanceConfigHob ();
+  CompleteInitialization ();
 
   return EFI_SUCCESS;
 }

--- a/Platforms/QemuQ35Pkg/PlatformPei/Platform.h
+++ b/Platforms/QemuQ35Pkg/PlatformPei/Platform.h
@@ -82,7 +82,7 @@ PeiFvInitialization (
   VOID
   );
 
-VOID
+EFI_STATUS
 MemTypeInfoInitialization (
   VOID
   );
@@ -128,5 +128,10 @@ extern UINT16  mHostBridgeDevId;
 extern BOOLEAN  mQ35SmramAtDefaultSmbase;
 
 extern UINT32  mQemuUc32Base;
+
+VOID
+CompleteInitialization (
+  VOID
+  );
 
 #endif // _PLATFORM_PEI_H_INCLUDED_

--- a/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
+++ b/Platforms/QemuQ35Pkg/QemuQ35Pkg.dsc
@@ -570,6 +570,7 @@
 #
 ################################################################################
 [PcdsFeatureFlag]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPeiMemoryBinsEnable|TRUE
   gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSupportUefiDecompress|FALSE
   gEfiMdeModulePkgTokenSpaceGuid.PcdDxeIplSwitchToLongMode|TRUE

--- a/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
@@ -2,9 +2,9 @@
     "scope": "qemu",
     "type": "web",
     "name": "DXECORE.QEMU",
-    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v3.0.6/patina_dxe_core_qemu.zip",
-    "version": "3.0.6",
-    "sha256": "75a3b2d418ae8a38a3705c53488d869d5a9a516cb41b88da4d716e94b10691fb",
+    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v3.0.8/patina_dxe_core_qemu.zip",
+    "version": "3.0.8",
+    "sha256": "7eb2eb789d8056b34824299fd85b7b91f822f1d1273fb11a6f54b4c1647f98bd",
     "internal_path": "/",
     "compression_type": "zip",
     "flags": [

--- a/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
@@ -2,9 +2,9 @@
     "scope": "qemu",
     "type": "web",
     "name": "DXECORE.QEMU",
-    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v3.0.1/patina_dxe_core_qemu.zip",
-    "version": "3.0.1",
-    "sha256": "45eb9fed11008cc5fe4df227c2dac3b10228a53536f6cff26690d11a8881fbb1",
+    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v3.0.6/patina_dxe_core_qemu.zip",
+    "version": "3.0.6",
+    "sha256": "75a3b2d418ae8a38a3705c53488d869d5a9a516cb41b88da4d716e94b10691fb",
     "internal_path": "/",
     "compression_type": "zip",
     "flags": [

--- a/QemuPkg/Binaries/READINESS.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/READINESS.QEMU_ext_dep.json
@@ -2,9 +2,9 @@
     "scope": "qemu",
     "type": "web",
     "name": "READINESS.QEMU",
-    "source": "https://github.com/OpenDevicePartnership/patina-readiness-tool/releases/download/v0.1.2/patina_readiness_tool.zip",
-    "version": "v0.1.2",
-    "sha256": "f83a3e3127bc428033b76873ae73cf67657313199f56d08963922418c0eb28b7",
+    "source": "https://github.com/OpenDevicePartnership/patina-readiness-tool/releases/download/v0.3.0/patina_readiness_tool.zip",
+    "version": "v0.3.0",
+    "sha256": "578d06d23cd739eb22d27314b545beac43cb9a13922a638c2aaae0c0ba39982e",
     "internal_path": "/",
     "compression_type": "zip",
     "flags": [


### PR DESCRIPTION
## Description

---

**QemuPkg: Update Patina DXE Core binary to v3.0.6**

Delta between the prior version (v3.0.1) and this version (v3.0.6):

https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/compare/v3.0.1...v3.0.6

---

**QemuPkg: Update Patina Readiness Tool to v0.3.0**

Updates to the latest release (0.3.0) from 0.2.1.

https://github.com/OpenDevicePartnership/patina-readiness-tool/compare/v0.1.2...v0.3.0

---

**QemuPkg: Update Patina DXE Core binary to v3.0.8**

Delta between the prior version (v3.0.6) and this version (v3.0.8):

https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/compare/v3.0.6...v3.0.8

---

**QemuQ35Pkg: Integrate PEI memory bins**

- Update to mu_basecore v2025110002.0.0 which contains PEI memory
  bin support + RT cache updates for the UEFI variable driver.
- Set `gEfiMdeModulePkgTokenSpaceGuid.PcdPeiMemoryBinsEnable` to
  TRUE to enable PEI memory bins.
- Port upstream changes for publishing memory type information from
  OvmfPkg to QemuQ35Pkg.

- Note: The patina DXE Core binary is already updated to v3.0.6 in an earlier commit which includes support for PEI memory bins.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Check that PEI bins are created and used throughout DXE

## Integration Instructions

- N/A