### PR TITLE
Fixing intermittent QEMU launching failure

### DIFF
--- a/Platforms/Common/Qemu/QemuCommandBuilder.py
+++ b/Platforms/Common/Qemu/QemuCommandBuilder.py
@@ -551,8 +551,8 @@ class QemuCommandBuilder:
         if port:
             self._args.extend(["-serial", f"tcp:{ip}:{port},server,nowait"])
         else:
-            self._args.extend(["-serial", "stdio"])
             if log_files:
+                self._args.extend(["-serial", "stdio"])
                 for log_file in log_files:
                     self._args.extend(["-serial", f"file:{log_file}"])
         return self

--- a/Platforms/Docs/Common/building.md
+++ b/Platforms/Docs/Common/building.md
@@ -123,7 +123,10 @@ an error occurs. Locally you don't need to set this.
 for debugging via the hardware debugger.
 
 **SERIAL_PORT=\<Serial Port\>** Enables the specified serial port to be used. Primarily this is used to connect to the
-software debugger when enabled. On Q35 this defaults to 50001. SBSA only has a single serial port for normal world and
+software debugger when enabled.
+- On Q35, this defaults to `None` to avoid unintended port conflicts in the pipeline. The
+  [build_and_run_rust_binary.py](#the-build_and_run_rust_binarypy-script) script defaults to port 50001.
+- SBSA only has a single serial port for normal world and
 so by default does not set this so it can send serial output to stdio. Setting this for SBSA will prevent logs from
 coming over stdio and instead will go to this TCP port.
 

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -110,7 +110,7 @@ class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):
         qemu_accelerator = QemuRunner.GetStr(env, "QEMU_ACCEL")
         qemu_executable_path = QemuRunner.GetStr(env, "QEMU_PATH")
         qemu_ext_dep_dir = QemuRunner.GetStr(env, "QEMU_DIR")
-        serial_port = QemuRunner.GetStr(env, "SERIAL_PORT", "50001")
+        serial_port = QemuRunner.GetStr(env, "SERIAL_PORT")
         tpm_dev = QemuRunner.GetStr(env, "TPM_DEV")
         virtual_drive = QemuRunner.GetStr(env, "VIRTUAL_DRIVE_PATH")
 


### PR DESCRIPTION
## Description

There have been intermittent pipeline failures on QEMU launching instances.

i.e. https://github.com/OpenDevicePartnership/patina-qemu/actions/runs/25468741289/job/74727751581#step:8:612

The theory is that multiple github action could be run on the same agent, which will clash with the other session in terms of the port number.

Resolves https://github.com/OpenDevicePartnership/patina-qemu/issues/245

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested locally and does not redirect the serial logs to port 50001.

## Integration Instructions

N/A
