### PR TITLE
workspace_setup.py: Fix QEMU path detection

### DIFF
--- a/workspace_setup.py
+++ b/workspace_setup.py
@@ -1043,6 +1043,10 @@ class _Wizard:
         """
         Q35_QEMU_EXEC = "qemu-system-x86_64"
         SBSA_QEMU_EXEC = "qemu-system-aarch64"
+        # executable names depend on OS
+        if platform.system() == "Windows":
+            Q35_QEMU_EXEC += ".exe"
+            SBSA_QEMU_EXEC += ".exe"    
 
         _LOGGER.info("\nSetting up patch configuration...")
 
@@ -1083,17 +1087,17 @@ class _Wizard:
             if qemu_ext_dep_path.exists():
                 if self._settings.package.upper() == "Q35":
                     if (qemu_ext_dep_path / Q35_QEMU_EXEC).exists():
-                        qemu_paths.append(qemu_ext_dep_path / Q35_QEMU_EXEC)
+                        qemu_paths.append(str(qemu_ext_dep_path / Q35_QEMU_EXEC))
                 elif self._settings.package.upper() == "SBSA":
                     if (qemu_ext_dep_path / SBSA_QEMU_EXEC).exists():
-                        qemu_paths.append(qemu_ext_dep_path / SBSA_QEMU_EXEC)
+                        qemu_paths.append(str(qemu_ext_dep_path / SBSA_QEMU_EXEC))
 
         # Check for qemu on the system path
         qemu_sys_path = None
         if self._settings.package.upper() == "Q35":
-            qemu_sys_path = shutil.which("qemu-system-x86_64")
+            qemu_sys_path = shutil.which(Q35_QEMU_EXEC)
         elif self._settings.package.upper() == "SBSA":
-            qemu_sys_path = shutil.which("qemu-system-aarch64")
+            qemu_sys_path = shutil.which(SBSA_QEMU_EXEC)
 
         if qemu_sys_path:
             qemu_paths.append(qemu_sys_path)
@@ -1109,11 +1113,13 @@ class _Wizard:
             )
 
             while True:
-                qemu_path = input().strip()
-                if os.path.isdir(qemu_path):
+                exe = Q35_QEMU_EXEC if self._settings.package.upper() == "Q35" else SBSA_QEMU_EXEC
+                qemu_path = Path(input().strip()) / exe
+                if qemu_path.exists() and qemu_path.is_file():
+                    qemu_path = str(qemu_path)
                     break
                 _LOGGER.error(
-                    "The provided path does not exist or is not a directory. Please enter a valid directory path:"
+                    "The provided path does not exist, is not a directory, or does not contain the QEMU executable. Please enter a valid directory path:"
                 )
         elif len(qemu_paths) > 1:
             _LOGGER.info("\nMultiple QEMU executables were found. Please select one:")


### PR DESCRIPTION
## Description

QEMU path detection was broken in multiple ways:

1. The QEMU external dependency could not be found on Windows because the executable name did not end in `.exe`. This was resolved by appending `.exe` to the constant name if on windows.

2. Once (1) was resolved, the path appended to `qemu_paths` was a `Path` object instead of a string, which would result in failing to write the object to the json configuration structure. This was resolved by wrapping the path in a `str` when appending to `qemu_paths`.

3. Once (2) was resolved, there was an inconsistency in what should go in `qemu_path`. If it was the extdep, the entire path, including the binary was added. Otherwise only the directory containing the executable was added. If one of the directory options was selected, and that path was written to the configuration file, building via `build_and_run_rust_binary` would fail because a directory was passed instead of the executable. This was resolved by having `qemu_paths` always be full paths to the executable, and the full path is written to the configuration file. Additionally, the querying of a path manually still expects the directory. Instead of validating that the directory exists, we instead validate that the executable exists in that directory.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. When providing a QEMU path manually, the path is only approved if it is a directory that contains the qemu executable we expected based off of if you selected Q35 or SBSA
2. The extdep QEMU path is now successfully found on windows
3. Once a path was selected, it is always the full path to the executable, and flashing the FW works as expected.

## Integration Instructions

N/A
