### PR TITLE
 [REBASE & FF] SBSA: Fix MM Comm Buffer Carveout

### DIFF
--- a/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
+++ b/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
@@ -33,6 +33,12 @@
                       EFI_RESOURCE_ATTRIBUTE_TESTED \
                       )
 
+#define MMIO_CAP  (EFI_RESOURCE_ATTRIBUTE_PRESENT | \
+                   EFI_RESOURCE_ATTRIBUTE_INITIALIZED | \
+                   EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE | \
+                   EFI_RESOURCE_ATTRIBUTE_TESTED \
+                   )
+
 // MU_CHANGE START
 
 /**
@@ -376,7 +382,7 @@ ArmPlatformGetVirtualMemoryMap (
   // CPUPERIPHS
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x40000000,
     0x00040000,
     EFI_MEMORY_UC,
@@ -386,7 +392,7 @@ ArmPlatformGetVirtualMemoryMap (
   // GIC_D
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x40060000,
     0x00010000,
     EFI_MEMORY_UC,
@@ -396,7 +402,7 @@ ArmPlatformGetVirtualMemoryMap (
   // GIC_R
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x40080000,
     0x04000000,
     EFI_MEMORY_UC,
@@ -406,7 +412,7 @@ ArmPlatformGetVirtualMemoryMap (
   // UART
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x60000000,
     0x1000,
     EFI_MEMORY_UC,
@@ -416,7 +422,7 @@ ArmPlatformGetVirtualMemoryMap (
   // SMMU
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x60050000,
     0x00020000,
     EFI_MEMORY_UC,
@@ -426,7 +432,7 @@ ArmPlatformGetVirtualMemoryMap (
   // AHCI
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x60100000,
     0x00010000,
     EFI_MEMORY_UC,
@@ -436,7 +442,7 @@ ArmPlatformGetVirtualMemoryMap (
   // XHCI
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x60110000,
     0x00010000,
     EFI_MEMORY_UC,
@@ -446,7 +452,7 @@ ArmPlatformGetVirtualMemoryMap (
   // PCIE_PIO
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x7fff0000,
     0x00010000,
     EFI_MEMORY_UC,
@@ -456,7 +462,7 @@ ArmPlatformGetVirtualMemoryMap (
   // PCIE_MMIO
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x80000000,
     0x70000000,
     EFI_MEMORY_UC,
@@ -466,7 +472,7 @@ ArmPlatformGetVirtualMemoryMap (
   // PCIE_ECAM
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0xf0000000,
     0x10000000,
     EFI_MEMORY_UC,
@@ -476,7 +482,7 @@ ArmPlatformGetVirtualMemoryMap (
   // Watchdog Refresh
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x50010000,
     0x00001000,
     EFI_MEMORY_UC,
@@ -486,7 +492,7 @@ ArmPlatformGetVirtualMemoryMap (
   // Watchdog Control
   BuildResourceDescriptorV2 (
     EFI_RESOURCE_MEMORY_MAPPED_IO,
-    RESOURCE_CAP,
+    MMIO_CAP,
     0x50011000,
     0x00001000,
     EFI_MEMORY_UC,

--- a/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
+++ b/Platforms/QemuSbsaPkg/Library/SbsaQemuLib/SbsaQemuMem.c
@@ -187,19 +187,58 @@ InitializeMemoryConfiguration (
   }
 
   if (NewSize > PcdGet64 (PcdSystemMemorySize)) {
-    BuildResourceDescriptorV2 (
-      EFI_RESOURCE_SYSTEM_MEMORY,
-      (EFI_RESOURCE_ATTRIBUTE_PRESENT |
-       EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
-       EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
-       EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
-       EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
-       EFI_RESOURCE_ATTRIBUTE_TESTED),
-      NewBase + PcdGet64 (PcdSystemMemorySize),
-      NewSize - PcdGet64 (PcdSystemMemorySize),
-      EFI_MEMORY_WB,
-      NULL
-      );
+    if ((PcdGet64 (PcdMmBufferBase) > PcdGet64 (PcdSystemMemoryBase)) && (PcdGet64 (PcdMmBufferBase) < NewBase + NewSize)) {
+      // Carve out the MM buffer from the available memory, it is added as a HOB elsewhere. This only matters when
+      // adding more memory as PcdSystemMemoryBase + PcdSystemMemorySize is less than PcdMmBufferBase.
+
+      // Memory between the end of PcdSystemMemorySize and the start of the MM buffer
+      if (PcdGet64 (PcdMmBufferBase) > NewBase + PcdGet64 (PcdSystemMemorySize)) {
+        BuildResourceDescriptorV2 (
+          EFI_RESOURCE_SYSTEM_MEMORY,
+          (EFI_RESOURCE_ATTRIBUTE_PRESENT |
+           EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_TESTED),
+          NewBase + PcdGet64 (PcdSystemMemorySize),
+          PcdGet64 (PcdMmBufferBase) - (NewBase + PcdGet64 (PcdSystemMemorySize)),
+          EFI_MEMORY_WB,
+          NULL
+          );
+      }
+
+      // Memory after the MM buffer, if any remains
+      if (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize) < NewBase + NewSize) {
+        BuildResourceDescriptorV2 (
+          EFI_RESOURCE_SYSTEM_MEMORY,
+          (EFI_RESOURCE_ATTRIBUTE_PRESENT |
+           EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+           EFI_RESOURCE_ATTRIBUTE_TESTED),
+          PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize),
+          (NewBase + NewSize) - (PcdGet64 (PcdMmBufferBase) + PcdGet64 (PcdMmBufferSize)),
+          EFI_MEMORY_WB,
+          NULL
+          );
+      }
+    } else {
+      BuildResourceDescriptorV2 (
+        EFI_RESOURCE_SYSTEM_MEMORY,
+        (EFI_RESOURCE_ATTRIBUTE_PRESENT |
+         EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+         EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+         EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+         EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE |
+         EFI_RESOURCE_ATTRIBUTE_TESTED),
+        NewBase + PcdGet64 (PcdSystemMemorySize),
+        NewSize - PcdGet64 (PcdSystemMemorySize),
+        EFI_MEMORY_WB,
+        NULL
+        );
+    }
   } else {
     NewSize = PcdGet64 (PcdSystemMemorySize);
   }
@@ -275,12 +314,6 @@ ArmPlatformGetVirtualMemoryMap (
     DEBUG ((DEBUG_INFO, "%a: TPM @ 0x%lx\n", __func__, TpmBase));
     BuildMemoryAllocationHob (TpmBase, TpmSize, EfiACPIMemoryNVS);
   }
-
-  BuildMemoryAllocationHob (
-    PcdGet64 (PcdMmBufferBase),
-    PcdGet64 (PcdMmBufferSize),
-    EfiReservedMemoryType
-    );
 
   BuildMemoryAllocationHob (
     PcdGet64 (PcdAdvancedLoggerBase),
@@ -470,7 +503,16 @@ ArmPlatformGetVirtualMemoryMap (
   VirtualMemoryTable[3].PhysicalBase = PcdGet64 (PcdMmBufferBase);
   VirtualMemoryTable[3].VirtualBase  = PcdGet64 (PcdMmBufferBase);
   VirtualMemoryTable[3].Length       = PcdGet64 (PcdMmBufferSize);
-  VirtualMemoryTable[3].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_UNCACHED_UNBUFFERED;
+  VirtualMemoryTable[3].Attributes   = ARM_MEMORY_REGION_ATTRIBUTE_WRITE_BACK;
+
+  BuildResourceDescriptorV2 (
+    EFI_RESOURCE_MEMORY_RESERVED,
+    RESOURCE_CAP,
+    VirtualMemoryTable[3].PhysicalBase,
+    VirtualMemoryTable[3].Length,
+    EFI_MEMORY_WB,
+    NULL
+    );
 
   // End of Table
   ZeroMem (&VirtualMemoryTable[4], sizeof (ARM_MEMORY_REGION_DESCRIPTOR));


### PR DESCRIPTION
## Description

mu_basecore was updated to have ArmMmCommunicationDxe expect the MM comm buffer either be unmapped or have a reserved resource descriptor HOB. SBSA was mapping it as part of the system memory HOB, so hit an assert. This updates mu_basecore and splits out the MM Comm Buffer into a separate reserved HOB.

It also fixes MMIO HOBs to only report UC as a capability, because OSes will map a region as WB if the EFI_MEMORY_MAP contains WB in the attribute (capability) field.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

SBSA boots to shell without the assert now.

## Integration Instructions

N/A.
