### PR TITLE
SBSA: Fix Serial Logging in Build and Run Script

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -407,7 +407,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
             .with_display(not args.headless)
             .with_network(enabled=False)
             .with_gdb_server(args.gdb_port)
-            .with_serial_port(args.serial_port)
+            .with_serial_port(args.serial_port, log_files=["secure.log", "secure_mm.log"])
             .with_monitor_port(args.monitor_port)
         )
 


### PR DESCRIPTION
## Description

ba21a244161fc66ffa9c576e95f8910db7867d17 changed how serial logging was handled but didn't update the build and run script. This dropped serial logging for SBSA using that script.

This fixes it and gets stuart_build parity by adding log files to trigger also getting serial to stdio.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running the build and run script and getting serial output.

## Integration Instructions

N/A.
