### PR TITLE
[doc] Remove sbsa reference from comments and documents

### DIFF
--- a/Platforms/QemuArmVirtPkg/Library/ArmPlatformLibQemu/ArmPlatformLibQemu.c
+++ b/Platforms/QemuArmVirtPkg/Library/ArmPlatformLibQemu/ArmPlatformLibQemu.c
@@ -235,9 +235,7 @@ InitializeMemoryConfiguration (
     }
 
     // Get the 'reg' property of this node. We assume two 8-byte quantities
-    // for base and size, respectively (true on QEMU virt and SBSA-ref, both
-    // of which use #address-cells=<2> and #size-cells=<2> on the root). A
-    // bank with multiple (base,size) tuples is currently not split out.
+    // for base and size, respectively.
     PropertyPtr = FdtGetProperty (DeviceTreeBase, Node, "reg", &Len);
     if (PropertyPtr == NULL) {
       DEBUG ((DEBUG_ERROR, "%a: Memory node has no 'reg' property\n", __func__));

--- a/Platforms/QemuArmVirtPkg/Library/ArmPlatformLibQemu/ArmPlatformLibQemuMpCoreInfo.c
+++ b/Platforms/QemuArmVirtPkg/Library/ArmPlatformLibQemu/ArmPlatformLibQemuMpCoreInfo.c
@@ -3,9 +3,6 @@
   ArmPlatformGetPlatformPpiList for QEMU/arm-virt: publishes CPU topology
   via ARM_MP_CORE_INFO_PPI by walking /cpus/cpu@N in the DTB.
 
-  TF-A's "qemu" platform (unlike SBSA) exposes no SiP service for CPU
-  enumeration, so the DTB is the canonical source.
-
   This library runs XIP (no writable .data), so each
   PrePeiCoreGetMpCoreInfo() call re-walks the DTB and allocates a fresh
   ARM_CORE_INFO table; the PPI caller copies it into a HOB.

--- a/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
+++ b/Platforms/QemuQ35Pkg/Plugins/QemuRunner/QemuRunner.py
@@ -19,7 +19,7 @@ from QemuCommandBuilder import QemuCommandBuilder
 from QemuCommandBuilder import QemuArchitecture
 
 
-# """QEMU Command Builder for Q35 and SBSA architectures"""
+# """QEMU Command Builder for Q35 and ArmVirt architectures"""
 
 
 class QemuRunner(uefi_helper_plugin.IUefiHelperPlugin):

--- a/QemuPkg/QemuVideoDxe/ReadMe.md
+++ b/QemuPkg/QemuVideoDxe/ReadMe.md
@@ -5,7 +5,7 @@
 This driver is derived from the sample GOP driver QemuVideoDxe in QemuQ35Pkg.
 It replaces the standard GOP interfaces GUID with MsGopOverrideProtocolGuid.
 
-It removes support for Cirrus in favor of BOCHS used by SBSA.
+It removes support for Cirrus in favor of BOCHS used by QEMU Q35 and ArmVirt.
 
 ## Copyright
 

--- a/docs/src/testing/regression_testing.md
+++ b/docs/src/testing/regression_testing.md
@@ -16,18 +16,18 @@ drive, from a USB drive, and from a PXE server.
 
 - ✅ Q35 Internal Drive Windows Validation OS boot
 - ✅ Q35 Internal Drive Ubuntu 24.04 Server OS boot
-- ✅ SBSA Internal Drive Windows Validation OS boot
-- ✅ SBSA Internal Drive Ubuntu 24.04 Server OS boot
+- ✅ ArmVirt Internal Drive Windows Validation OS boot
+- ✅ ArmVirt Internal Drive Ubuntu 24.04 Server OS boot
 
 - ✅ Q35 USB Drive Windows Validation OS boot
 - ✅ Q35 USB Drive Ubuntu 24.04 Server OS boot
-- ✅ SBSA USB Drive Windows Validation OS boot
-- ✅ SBSA USB Drive Ubuntu 24.04 Server OS boot
+- ✅ ArmVirt USB Drive Windows Validation OS boot
+- ✅ ArmVirt USB Drive Ubuntu 24.04 Server OS boot
 
 - ❌ Q35 PXE Windows Validation OS boot
 - ❌ Q35 PXE Ubuntu 24.04 Server OS boot
-- ❌ SBSA PXE Windows Validation OS boot
-- ❌ SBSA PXE Ubuntu 24.04 Server OS boot
+- ❌ ArmVirt PXE Windows Validation OS boot
+- ❌ ArmVirt PXE Ubuntu 24.04 Server OS boot
 
 The [`.github/workflows/nightly-os-boot.yml`](https://github.com/OpenDevicePartnership/patina-qemu/blob/main/.github/workflows/nightly-os-boot.yml)
 workflow is responsible for the nightly OS boot testing mentioned above. It first downloads and prepares the OS
@@ -42,9 +42,9 @@ debugger), it can take time to notice if this functionality is broken. This nigh
 logs exist and are retrievable from Windows systems once booted to the operating system.
 
 - ✅ Q35 advanced logger boot log gathering via UEFI application
-- ✅ SBSA advanced logger boot log gathering via UEFI application
+- ✅ ArmVirt advanced logger boot log gathering via UEFI application
 - ❌ Q35 advanced logger boot log gathering via Windows Validation OS
-- ❌ SBSA advanced logger boot log gathering via Windows Validation OS
+- ❌ ArmVirt advanced logger boot log gathering via Windows Validation OS
 
 ## Debugger Connection
 
@@ -53,7 +53,7 @@ immediately. Nightly tests boot with the debugger and initial breakpoint enabled
 Protocol communication to ensure the debugger successfully connects and continues from the initial breakpoint.
 
 - ❌ Q35 debugger connection boot
-- ❌ SBSA debugger connection boot
+- ❌ ArmVirt debugger connection boot
 
 ## Hibernation
 
@@ -68,7 +68,7 @@ performs a hibernate-resume cycle. This process is repeated multiple times to de
 that could cause resume failures.
 
 - ❌ Q35 hibernate resume
-- ❌ SBSA hibernate resume
+- ❌ ArmVirt hibernate resume
 
 ## Self-Certification Tests (SCTs)
 
@@ -77,7 +77,7 @@ It is important to monitor and stay compliant with these tests. Unlike other tes
 weekly basis due to the time it takes to run them.
 
 - ❌ Q35 self-certification tests
-- ❌ SBSA self-certification tests
+- ❌ ArmVirt self-certification tests
 
 ## Performance Monitoring
 
@@ -93,4 +93,4 @@ compares them against the most recent measurements from the scheduled run, comme
 performance changes.
 
 - ❌ Q35 Release Performance Measurement tracking
-- ❌ SBSA Release Performance Measurement tracking
+- ❌ ArmVirt Release Performance Measurement tracking


### PR DESCRIPTION
## Description

As trasition from SBSA to ARM virt complete, this PR removes the minor docs and comment that are still in place referencing the SBSA platform.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Non-functional change.

## Integration Instructions

N/A
