### PR TITLE
[aarch64] STMM print through SPMC console

### DIFF
--- a/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
+++ b/Platforms/QemuArmVirtPkg/QemuArmVirtPkg.dsc
@@ -482,7 +482,7 @@
 [LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.MM_STANDALONE]
   # Current support of advanced logger in Standalone MM is limited to the platforms
   # that supports it from TFA.
-  DebugLib|MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+  DebugLib|MdeModulePkg/Library/ArmFfaConsoleDebugLib/ArmFfaConsoleDebugStandaloneMmLib.inf
 
 [BuildOptions]
 !include NetworkPkg/NetworkBuildOptions.dsc.inc
@@ -1140,7 +1140,6 @@
       NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
     <PcdsFixedAtBuild>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
-      gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x09040000
       gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|62500000
     <PcdsPatchableInModule>
       gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
@@ -1149,13 +1148,15 @@
   ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf {
     <PcdsFixedAtBuild>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
-      gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x09040000
       gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|62500000
+    <PcdsPatchableInModule>
+      gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
   }
   MdeModulePkg/Universal/FaultTolerantWriteDxe/FaultTolerantWriteStandaloneMm.inf {
     <PcdsFixedAtBuild>
-      gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x09040000
       gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|62500000
+    <PcdsPatchableInModule>
+      gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
   }
   MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf {
     <LibraryClasses>
@@ -1167,20 +1168,23 @@
       VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
       VariablePolicyHelperLib|MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
     <PcdsFixedAtBuild>
-      gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x09040000
       gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|62500000
+    <PcdsPatchableInModule>
+      gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
   }
 !if $(TPM2_ENABLE) == TRUE
   SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.inf {
     <PcdsFixedAtBuild>
-      gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x09040000
       gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|62500000
+    <PcdsPatchableInModule>
+      gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
   }
 !endif
   QemuArmVirtPkg/VirtNorFlashStandaloneMm/VirtNorFlashStandaloneMm.inf {
     <PcdsFixedAtBuild>
-      gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0x09040000
       gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|62500000
+    <PcdsPatchableInModule>
+      gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
   }
 
   # FF-A test application to test the FF-A interface

--- a/Platforms/QemuArmVirtPkg/fdts/qemu_virt_stmm_config.dts
+++ b/Platforms/QemuArmVirtPkg/fdts/qemu_virt_stmm_config.dts
@@ -51,15 +51,6 @@
 		compatible = "arm,ffa-manifest-device-regions";
 
 		/*
-		 * Secure UART region.
-		 */
-		secure_uart {
-			base-address = <0x0 0x09040000>;
-			pages-count = <0x1>;
-			attributes = <0x3>;
-		};
-
-		/*
 		 * Variable Flash.
 		 */
 		variable_flash {


### PR DESCRIPTION
## Description

This change moves the STMM partition to print through the SPMC. This creates a centralized method for all secure partitions to go through the same console managed by SPMC (hafnium) and opens a spare UART port for other secure operations.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on ARM Virt platform and booted to UEFI shell.

## Integration Instructions

N/A
