### PR TITLE
[aarch64] Shorten pipeline timeout to 15min

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -128,7 +128,7 @@ jobs:
           stuart-args: 'SHUTDOWN_AFTER_RUN=TRUE FILE_REGEX=*TestApp*.efi RUN_TESTS=TRUE QEMU_HEADLESS=TRUE'
 
       - name: Run ${{ matrix.platform }} ${{ matrix.target }} ${{ matrix.os == 'windows-latest' && 'Windows' || 'Linux' }}
-        timeout-minutes: 20
+        timeout-minutes: 15
         uses: ./.github/actions/build-platform
         with:
           command: 'flash'


### PR DESCRIPTION
## Description

During ARM virt to SBSA switch, the timeout for running unit tests on pipeline is extended to 20min. The time was mainly spent on  WHEA tests, which will iterate through all the HwErrRec#### variables.

This change picks up the updated test application that will not iterate through the variable storage every time on all tests, which will speed up the test time by > 5min.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on QEMU Arm Virt and noticed the test time dropped from 8min to below 2min.

## Integration Instructions

N/A
