### PR TITLE
Cleanup serial port usage and documentation [FF & REBASE]

### DIFF
--- a/.github/workflows/build-haf-tfa.yml
+++ b/.github/workflows/build-haf-tfa.yml
@@ -13,10 +13,7 @@ on:
       - published
   pull_request:
     branches:
-      - '**'  # Matches all branches
-    paths:
-      - 'Platforms/QemuArmVirtPkg/**'
-      - 'Silicon/Arm/**'
+      - main
   workflow_dispatch:
 
 jobs:

--- a/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
+++ b/QemuPkg/Binaries/DXECORE.QEMU_ext_dep.json
@@ -2,9 +2,9 @@
     "scope": "qemu",
     "type": "web",
     "name": "DXECORE.QEMU",
-    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v3.0.8/patina_dxe_core_qemu.zip",
-    "version": "3.0.8",
-    "sha256": "7eb2eb789d8056b34824299fd85b7b91f822f1d1273fb11a6f54b4c1647f98bd",
+    "source": "https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/releases/download/v3.0.11/patina_dxe_core_qemu.zip",
+    "version": "3.0.11",
+    "sha256": "b201236dbb1063788ba459f410e71d7cf9bab7cfe4952cd6583fc36dd790d13d",
     "internal_path": "/",
     "compression_type": "zip",
     "flags": [

--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -278,10 +278,6 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
             build_cmd.append("--crate-patch ")
             build_cmd.append(str(p.resolve()))
 
-        # if a serial port wasn't specified, use the default port so a debugger can be retroactively attached
-        if args.serial_port is None:
-            args.serial_port = 50001
-
         if args.qemu_path:
             qemu_exec = args.qemu_path
         elif os.name == "nt":

--- a/docs/src/building/building.md
+++ b/docs/src/building/building.md
@@ -124,8 +124,9 @@ as those projects do not build natively on Windows. They still use clang to comp
 
 - **Q35**: defaults to `None` to avoid unintended port conflicts in the pipeline. The
   [build_and_run_rust_binary.py](rapid_iteration.md) script defaults to port `50001`.
-- **ARM Virt**: only has a single serial port for normal world. By default, this is unset so it can send serial output to
-  stdio. Setting it for ARM Virt prevents logs from coming over stdio and instead routes them to the TCP port.
+- **ARM Virt**: defaults to `None`. When set, a separate virtio serial port is exposed on the specified TCP port for
+  use by the software debugger. Log output continues to be sent to stdio regardless of this setting, consistent with
+  Q35 where the serial port is separate from `debugcon` used for logging.
 
 ### Passing Build Defines
 


### PR DESCRIPTION
## Description

With the introduction of the VirtIO serial port, the behavior of the serial port parameter no longer matches the documentation. This commit clarifies the expected behavior.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
