### PR TITLE
Default ArmVirt build and run to NVMe

### DIFF
--- a/build_and_run_rust_binary.py
+++ b/build_and_run_rust_binary.py
@@ -418,7 +418,7 @@ def _configure_settings(args: argparse.Namespace) -> Dict[str, Path]:
             .with_usb_controller()
             .with_usb_mouse()
             .with_usb_keyboard()
-            .with_storage(args.os, 'HDD')
+            .with_storage(args.os, 'SSD')
             .with_display(not args.headless)
             .with_network(enabled=False)
             .with_gdb_server(args.gdb_port)


### PR DESCRIPTION
## Description

ArmVirt is using NVMe for an OS drive with stuart_build, but it wasn't updated in the build and run script, which left it broken (it errors).

There had been a Windows issue that didn't let NVMe boot on SBSA, but that has been resolved with ArmVirt.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running an OS with the script.

## Integration Instructions

N/A.
